### PR TITLE
Fixed temperate gardens generation

### DIFF
--- a/angelsbioprocessing/changelog.txt
+++ b/angelsbioprocessing/changelog.txt
@@ -6,6 +6,7 @@ Date: ??
   Bugfixes:
     - Fixed petri-dish requiring the wrong glass item (when playing with bob)
     - Updated emission data, so it now shows in the ingame toolips (and activates)
+    - Fixed that there where no temperate gardens generating under any circumstances
 ---------------------------------------------------------------------------------------------------
 Version: 0.7.2
 Date: 12.02.2020

--- a/angelsbioprocessing/prototypes/buildings/gardens.lua
+++ b/angelsbioprocessing/prototypes/buildings/gardens.lua
@@ -32,7 +32,7 @@ data:extend(
     vehicle_impact_sound =  { filename = "__base__/sound/car-wood-impact.ogg", volume = 1.0 },
     autoplace =
     {
-      order = "za",
+      order = "xa",
       max_probability = 0.025,
       peaks =
       {
@@ -120,7 +120,7 @@ data:extend(
     vehicle_impact_sound =  { filename = "__base__/sound/car-wood-impact.ogg", volume = 1.0 },
     autoplace =
     {
-      order = "zb",
+      order = "ya",
       max_probability = 0.025,
       peaks =
       {
@@ -201,7 +201,7 @@ data:extend(
     vehicle_impact_sound =  { filename = "__base__/sound/car-wood-impact.ogg", volume = 1.0 },
     autoplace =
     {
-      order = "zc",
+      order = "ya",
       max_probability = 0.025,
       peaks =
       {

--- a/angelsbioprocessing/prototypes/buildings/gardens.lua
+++ b/angelsbioprocessing/prototypes/buildings/gardens.lua
@@ -42,9 +42,9 @@ data:extend(
         {
           influence = 0.0005,
           min_influence = 0,
-          water_optimal = 0.5,
-          water_range = 0.2,
-          water_max_range = 0.3,
+          water_optimal = 0.6,
+          water_range = 0.1,
+          water_max_range = 0.15,
         }
       },
       --tile_restriction = {"grass-1", "grass-2", "grass-3", "grass-4", "dry-dirt"},
@@ -130,7 +130,7 @@ data:extend(
         {
           influence = 0.0005,
           min_influence = 0,
-          water_optimal = 0.1,
+          water_optimal = 0.225,
           water_range = 0.1,
           water_max_range = 0.15,
         }

--- a/angelsbioprocessing/prototypes/buildings/gardens.lua
+++ b/angelsbioprocessing/prototypes/buildings/gardens.lua
@@ -32,7 +32,7 @@ data:extend(
     vehicle_impact_sound =  { filename = "__base__/sound/car-wood-impact.ogg", volume = 1.0 },
     autoplace =
     {
-      order = "xa",
+      order = "xab",
       max_probability = 0.025,
       peaks =
       {
@@ -120,7 +120,7 @@ data:extend(
     vehicle_impact_sound =  { filename = "__base__/sound/car-wood-impact.ogg", volume = 1.0 },
     autoplace =
     {
-      order = "ya",
+      order = "yab",
       max_probability = 0.025,
       peaks =
       {
@@ -201,7 +201,7 @@ data:extend(
     vehicle_impact_sound =  { filename = "__base__/sound/car-wood-impact.ogg", volume = 1.0 },
     autoplace =
     {
-      order = "ya",
+      order = "yab",
       max_probability = 0.025,
       peaks =
       {

--- a/angelsbioprocessing/prototypes/buildings/trees.lua
+++ b/angelsbioprocessing/prototypes/buildings/trees.lua
@@ -34,7 +34,7 @@ data:extend(
     vehicle_impact_sound =  { filename = "__base__/sound/car-wood-impact.ogg", volume = 1.0 },
     autoplace =
     {
-      order = "xa",
+      order = "xaa",
       max_probability = 0.025,
       peaks =
       {
@@ -104,7 +104,7 @@ data:extend(
     vehicle_impact_sound =  { filename = "__base__/sound/car-wood-impact.ogg", volume = 1.0 },
     autoplace =
     {
-      order = "ya",
+      order = "yaa",
       max_probability = 0.025,
       peaks =
       {
@@ -180,7 +180,7 @@ data:extend(
     vehicle_impact_sound =  { filename = "__base__/sound/car-wood-impact.ogg", volume = 1.0 },
     autoplace =
     {
-      order = "ya",
+      order = "yaa",
       max_probability = 0.025,
       peaks =
       {

--- a/angelsbioprocessing/prototypes/buildings/trees.lua
+++ b/angelsbioprocessing/prototypes/buildings/trees.lua
@@ -187,7 +187,7 @@ data:extend(
         {
           influence = 0.0005,
           min_influence = 0,
-          water_optimal = 0.375,
+          water_optimal = 0.25,
           water_range = 0.125,
           water_max_range = 0.125,
         }


### PR DESCRIPTION
Now it does generate more or less 50/50 trees/gardens:
![image](https://user-images.githubusercontent.com/26593477/74683951-b929f600-51ca-11ea-8900-49efcae06067.png)

The amounts per type (desert, temperate, swamp) depend on the map generation, which was in this case mostly desert. (full picture posted on the factorio forum thread). Resolves #39.