### PR TITLE
Mark crawler train optional

### DIFF
--- a/angelsindustries/info.json
+++ b/angelsindustries/info.json
@@ -13,7 +13,7 @@
     "angelspetrochem >= 0.9.0",
     "angelsbioprocessing >= 0.7.3",
     "angelssmelting >= 0.6.5",
-    "angelsaddons-crawlertrain >= 0.1.0",
+    "? angelsaddons-crawlertrain >= 0.1.0",
     "(?)bobtech >= 0.18.3"
   ]
 }


### PR DESCRIPTION
No were in industries is the crawler train really required so we can mark it optional to not force people into it.