### PR TITLE
MK consistency for tiered machines

### DIFF
--- a/angelsbioprocessing/locale/en/bio-processing.cfg
+++ b/angelsbioprocessing/locale/en/bio-processing.cfg
@@ -1,7 +1,7 @@
 [entity-name]
-algae-farm=Algae Farm MK1
-algae-farm-2=Algae Farm MK2
-algae-farm-3=Algae Farm MK3
+algae-farm=Algae Farm 1
+algae-farm-2=Algae Farm 2
+algae-farm-3=Algae Farm 3
 
 crop-farm=Basic Farm
 temperate-farm=Farm with Temperate Upgrade

--- a/angelsindustries/locale/en/logistic.cfg
+++ b/angelsindustries/locale/en/logistic.cfg
@@ -1,6 +1,6 @@
 [entity-name]
-cargo-robot=Crawler Cargo Robot
-cargo-robot-2=Crawler Cargo Robot MK2
+cargo-robot=Crawler Cargo Robot 1
+cargo-robot-2=Crawler Cargo Robot 2
 cargo-roboport=Crawler Roboport
 cargo-hub=Crawler Robohub
 cargo-box=Crawler Robobox

--- a/angelsindustries/locale/en/science.cfg
+++ b/angelsindustries/locale/en/science.cfg
@@ -1,24 +1,24 @@
 [entity-name]
 angels-main-lab=Tech Archive __1__
-angels-basic-lab=Basic Laboratory
+angels-basic-lab=Basic Laboratory 1
 angels-basic-lab-2=Basic Laboratory 2
 angels-basic-lab-3=Basic Laboratory 3
-angels-energy-lab-1=Energy Tech Laboratory
+angels-energy-lab-1=Energy Tech Laboratory 1
 angels-energy-lab-2=Energy Tech Laboratory 2
 angels-energy-lab-3=Energy Tech Laboratory 3
-angels-enhance-lab-1=Enhancement Tech Laboratory
+angels-enhance-lab-1=Enhancement Tech Laboratory 1
 angels-enhance-lab-2=Enhancement Tech Laboratory 2
 angels-enhance-lab-3=Enhancement Tech Laboratory 3
-angels-exploration-lab-1=Exploration Tech Laboratory
+angels-exploration-lab-1=Exploration Tech Laboratory 1
 angels-exploration-lab-2=Exploration Tech Laboratory 2
 angels-exploration-lab-3=Exploration Tech Laboratory 3
-angels-logistic-lab-1=Logistic Tech Laboratory
+angels-logistic-lab-1=Logistic Tech Laboratory 1
 angels-logistic-lab-2=Logistic Tech Laboratory 2
 angels-logistic-lab-3=Logistic Tech Laboratory 3
-angels-processing-lab-1=Processing Tech Laboratory
+angels-processing-lab-1=Processing Tech Laboratory 1
 angels-processing-lab-2=Processing Tech Laboratory 2
 angels-processing-lab-3=Processing Tech Laboratory 3
-angels-war-lab-1=Warfare Tech Laboratory
+angels-war-lab-1=Warfare Tech Laboratory 1
 angels-war-lab-2=Warfare Tech Laboratory 2
 angels-war-lab-3=Warfare Tech Laboratory 3
 

--- a/angelspetrochem/locale/en/petrochem.cfg
+++ b/angelspetrochem/locale/en/petrochem.cfg
@@ -215,54 +215,54 @@ angels-natural-gas=Gas Well
 [entity-name]
 angels-natural-gas=Gas Well
 
-advanced-chemical-plant=Advanced Chemical Plant
-advanced-chemical-plant-2=Advanced Chemical Plant MK2
+advanced-chemical-plant=Advanced Chemical Plant 1
+advanced-chemical-plant-2=Advanced Chemical Plant 2
 
 angels-flare-stack=Flare Stack
 
 angels-fluid-splitter-2-way=2 Way Fluid Splitter
 angels-fluid-splitter-3-way=3 Way Fluid Splitter
 
-gas-refinery-small=Gas Refinery
-gas-refinery-small-2=Gas Refinery MK2
-gas-refinery-small-3=Gas Refinery MK3
-gas-refinery-small-4=Gas Refinery MK4
+gas-refinery-small=Gas Refinery 1
+gas-refinery-small-2=Gas Refinery 2
+gas-refinery-small-3=Gas Refinery 3
+gas-refinery-small-4=Gas Refinery 4
 
-gas-refinery=Advanced Gas Refinery
-gas-refinery-2=Advanced Gas Refinery MK2
-gas-refinery-3=Advanced Gas Refinery MK3
-gas-refinery-4=Advanced Gas Refinery MK4
+gas-refinery=Advanced Gas Refinery 1
+gas-refinery-2=Advanced Gas Refinery 2
+gas-refinery-3=Advanced Gas Refinery 3
+gas-refinery-4=Advanced Gas Refinery 4
 
-separator=Oil & Gas Separator
-separator-2=Oil & Gas Separator MK2
-separator-3=Oil & Gas Separator MK3
-separator-4=Oil & Gas Separator MK4
+separator=Oil & Gas Separator 1
+separator-2=Oil & Gas Separator 2
+separator-3=Oil & Gas Separator 3
+separator-4=Oil & Gas Separator 4
 
-steam-cracker=Steam Cracker
-steam-cracker-2=Steam Cracker MK2
-steam-cracker-3=Steam Cracker MK3
-steam-cracker-4=Steam Cracker MK4
+steam-cracker=Steam Cracker 1
+steam-cracker-2=Steam Cracker 2
+steam-cracker-3=Steam Cracker 3
+steam-cracker-4=Steam Cracker 4
 
-angels-electrolyser=Electrolyser
-angels-electrolyser-2=Electrolyser MK2
-angels-electrolyser-3=Electrolyser MK3
-angels-electrolyser-4=Electrolyser MK4
+angels-electrolyser=Electrolyser 1
+angels-electrolyser-2=Electrolyser 2
+angels-electrolyser-3=Electrolyser 3
+angels-electrolyser-4=Electrolyser 4
 
 angels-storage-tank-1=Petrochem Gas Tank
 angels-storage-tank-2=Petrochem Oil Tank
 angels-storage-tank-3=Petrochem Small Inline Tank
 
-angels-air-filter=Air Filter
-angels-air-filter-2=Air Filter MK2
+angels-air-filter=Air Filter 1
+angels-air-filter-2=Air Filter 2
 
-angels-chemical-plant=Chemical Plant
-angels-chemical-plant-2=Chemical Plant MK2
-angels-chemical-plant-3=Chemical Plant MK3
-angels-chemical-plant-4=Chemical Plant MK4
+angels-chemical-plant=Chemical Plant 1
+angels-chemical-plant-2=Chemical Plant 2
+angels-chemical-plant-3=Chemical Plant 3
+angels-chemical-plant-4=Chemical Plant 4
 
-oil-refinery-2=Oil Refinery MK2
-oil-refinery-3=Oil Refinery MK3
-oil-refinery-4=Oil Refinery MK4
+oil-refinery-2=Oil Refinery 2
+oil-refinery-3=Oil Refinery 3
+oil-refinery-4=Oil Refinery 4
 
 valve-check=Check Valve
 valve-return=Non-Return Valve
@@ -270,9 +270,9 @@ valve-overflow=Overflow Valve
 valve-converter=Converter Valve
 valve-underflow=Top-Up Valve
 
-angels-electric-boiler=Electric Boiler
-angels-electric-boiler-2=Electric Boiler MK2
-angels-electric-boiler-3=Electric Boiler MK3
+angels-electric-boiler=Electric Boiler 1
+angels-electric-boiler-2=Electric Boiler 2
+angels-electric-boiler-3=Electric Boiler 3
 
 [item-name]
 solid-sodium-hydroxide=Sodium Hydroxide
@@ -322,45 +322,45 @@ rocket-booster=Rocket Booster
 
 chemical-void=Chemical Void
 
-advanced-chemical-plant=Advanced Chemical Plant
-advanced-chemical-plant-2=Advanced Chemical Plant MK2
+advanced-chemical-plant=Advanced Chemical Plant 1
+advanced-chemical-plant-2=Advanced Chemical Plant 2
 
 angels-flare-stack=Flare Stack
 
 angels-fluid-splitter-2-way=2 Way Fluid Splitter
 angels-fluid-splitter-3-way=3 Way Fluid Splitter
 
-gas-refinery-small=Gas Refinery
-gas-refinery-small-2=Gas Refinery MK2
-gas-refinery-small-3=Gas Refinery MK3
-gas-refinery-small-4=Gas Refinery MK4
+gas-refinery-small=Gas Refinery 1
+gas-refinery-small-2=Gas Refinery 2
+gas-refinery-small-3=Gas Refinery 3
+gas-refinery-small-4=Gas Refinery 4
 
-gas-refinery=Advanced Gas Refinery
-gas-refinery-2=Advanced Gas Refinery MK2
-gas-refinery-3=Advanced Gas Refinery MK3
-gas-refinery-4=Advanced Gas Refinery MK4
+gas-refinery=Advanced Gas Refinery 1
+gas-refinery-2=Advanced Gas Refinery 2
+gas-refinery-3=Advanced Gas Refinery 3
+gas-refinery-4=Advanced Gas Refinery 4
 
-separator=Oil & Gas Separator
-separator-2=Oil & Gas Separator MK2
-separator-3=Oil & Gas Separator MK3
-separator-4=Oil & Gas Separator MK4
+separator=Oil & Gas Separator 1
+separator-2=Oil & Gas Separator 2
+separator-3=Oil & Gas Separator 3
+separator-4=Oil & Gas Separator 4
 
-steam-cracker=Steam Cracker
-steam-cracker-2=Steam Cracker MK2
-steam-cracker-3=Steam Cracker MK3
-steam-cracker-4=Steam Cracker MK4
+steam-cracker=Steam Cracker 1
+steam-cracker-2=Steam Cracker 2
+steam-cracker-3=Steam Cracker 3
+steam-cracker-4=Steam Cracker 4
 
-angels-electrolyser=Electrolyser
-angels-electrolyser-2=Electrolyser MK2
-angels-electrolyser-3=Electrolyser MK3
-angels-electrolyser-4=Electrolyser MK4
+angels-electrolyser=Electrolyser 1
+angels-electrolyser-2=Electrolyser 2
+angels-electrolyser-3=Electrolyser 3
+angels-electrolyser-4=Electrolyser 4
 
 angels-storage-tank-1=Petrochem Gas Tank
 angels-storage-tank-2=Petrochem Oil Tank
 angels-storage-tank-3=Petrochem Small Inline Tank
 
-angels-air-filter=Air Filter
-angels-air-filter-2=Air Filter MK2
+angels-air-filter=Air Filter 1
+angels-air-filter-2=Air Filter 2
 
 valve-check=Check Valve
 valve-return=Non Return Valve

--- a/angelsrefining/locale/en/ore-refining.cfg
+++ b/angelsrefining/locale/en/ore-refining.cfg
@@ -11,44 +11,44 @@ angels-fissure=Fissure
 angels-crystal-rock=Crystal Rock
 
 burner-ore-crusher=Burner Ore Crusher
-ore-crusher=Ore Crusher
-ore-crusher-2=Ore Crusher Mk 2
-ore-crusher-3=Ore Crusher Mk 3
+ore-crusher=Ore Crusher 1
+ore-crusher-2=Ore Crusher 2
+ore-crusher-3=Ore Crusher 3
 
-ore-floatation-cell=Floatation Cell
-ore-floatation-cell-2=Floatation Cell Mk 2
-ore-floatation-cell-3=Floatation Cell Mk 3
+ore-floatation-cell=Floatation Cell 1
+ore-floatation-cell-2=Floatation Cell 2
+ore-floatation-cell-3=Floatation Cell 3
 
-ore-leaching-plant=Leaching Plant
-ore-leaching-plant-2=Leaching Plant Mk 2
-ore-leaching-plant-3=Leaching Plant Mk 3
+ore-leaching-plant=Leaching Plant 1
+ore-leaching-plant-2=Leaching Plant 2
+ore-leaching-plant-3=Leaching Plant 3
 
-ore-refinery=Ore Refinery
-ore-refinery-2=Ore Refinery Mk 2
-ore-refinery-3=Ore Refinery Mk 3
+ore-refinery=Ore Refinery 1
+ore-refinery-2=Ore Refinery 2
+ore-refinery-3=Ore Refinery 3
 
-ore-sorting-facility=Ore Sorting Facility
-ore-sorting-facility-2=Ore Sorting Facility Mk 2
-ore-sorting-facility-3=Ore Sorting Facility Mk 3
-ore-sorting-facility-4=Ore Sorting Facility Mk 4
+ore-sorting-facility=Ore Sorting Facility 1
+ore-sorting-facility-2=Ore Sorting Facility 2
+ore-sorting-facility-3=Ore Sorting Facility 3
+ore-sorting-facility-4=Ore Sorting Facility 4
 
-liquifier=Liquifier
-liquifier-2=Liquifier Mk 2
-liquifier-3=Liquifier Mk 3
-liquifier-4=Liquifier Mk 4
+liquifier=Liquifier 1
+liquifier-2=Liquifier 2
+liquifier-3=Liquifier 3
+liquifier-4=Liquifier 4
 
-electro-whinning-cell=Electro Whinning Cell
-electro-whinning-cell-2=Electro Whinning Cell MK2
-electro-whinning-cell-3=Electro Whinning Cell MK3
+electro-whinning-cell=Electro Whinning Cell 1
+electro-whinning-cell-2=Electro Whinning Cell 2
+electro-whinning-cell-3=Electro Whinning Cell 3
 
-ore-powderizer=Ore Powderizer
-ore-powderizer-2=Ore Powderizer MK2
-ore-powderizer-3=Ore Powderizer MK3
+ore-powderizer=Ore Powderizer 1
+ore-powderizer-2=Ore Powderizer 2
+ore-powderizer-3=Ore Powderizer 3
 
-filtration-unit=Filtration Unit
-filtration-unit-2=Filtration Unit Mk 2
-crystallizer=Crystallizer
-crystallizer-2=Crystallizer Mk 2
+filtration-unit=Filtration Unit1
+filtration-unit-2=Filtration Unit 2
+crystallizer=Crystallizer 1
+crystallizer-2=Crystallizer 2
 
 thermal-bore=Thermal Water Bore
 thermal-extractor=Thermal Water Extractor

--- a/angelsrefining/locale/en/water-treatment.cfg
+++ b/angelsrefining/locale/en/water-treatment.cfg
@@ -44,15 +44,15 @@ water-treatment=Water Treatment
 angels-fluid-control=Barreling and Fluid Control
 
 [entity-name]
-hydro-plant=Hydro Plant
-hydro-plant-2=Hydro Plant Mk2
-hydro-plant-3=Hydro Plant Mk3
+hydro-plant=Hydro Plant 1
+hydro-plant-2=Hydro Plant 2
+hydro-plant-3=Hydro Plant 3
 clarifier=Clarifier
-salination-plant=Salination Plant
-salination-plant-2=Salination Plant Mk2
+salination-plant=Salination Plant 1
+salination-plant-2=Salination Plant 2
 seafloor-pump=Seafloor Pump
-washing-plant=Washing Plant
-washing-plant-2=Washing Plant MK2
+washing-plant=Washing Plant 1
+washing-plant-2=Washing Plant 2
 barreling-pump=Barreling Pump
 
 [item-name]

--- a/angelssmelting/locale/en/smelting.cfg
+++ b/angelssmelting/locale/en/smelting.cfg
@@ -53,50 +53,50 @@ angels-smelting=Metallurgy Smelting
 angels-casting=Metallurgy Casting
 
 [entity-name]
-blast-furnace=Blast Furnace MK1
-blast-furnace-2=Blast Furnace MK2
-blast-furnace-3=Blast Furnace MK3
-blast-furnace-4=Blast Furnace MK4
+blast-furnace=Blast Furnace 1
+blast-furnace-2=Blast Furnace 2
+blast-furnace-3=Blast Furnace 3
+blast-furnace-4=Blast Furnace 4
 
-angels-chemical-furnace=Chemical Furnace MK1
-angels-chemical-furnace-2=Chemical Furnace MK2
-angels-chemical-furnace-3=Chemical Furnace MK3
-angels-chemical-furnace-4=Chemical Furnace MK4
+angels-chemical-furnace=Chemical Furnace 1
+angels-chemical-furnace-2=Chemical Furnace 2
+angels-chemical-furnace-3=Chemical Furnace 3
+angels-chemical-furnace-4=Chemical Furnace 4
 
-powder-mixer=Powder Mixer MK1
-powder-mixer-2=Powder Mixer MK2
-powder-mixer-3=Powder Mixer MK3
-powder-mixer-4=Powder Mixer MK4
+powder-mixer=Powder Mixer 1
+powder-mixer-2=Powder Mixer 2
+powder-mixer-3=Powder Mixer 3
+powder-mixer-4=Powder Mixer 4
 
-induction-furnace=Induction Furnace MK1
-induction-furnace-2=Induction Furnace MK2
-induction-furnace-3=Induction Furnace MK3
-induction-furnace-4=Induction Furnace MK4
+induction-furnace=Induction Furnace 1
+induction-furnace-2=Induction Furnace 2
+induction-furnace-3=Induction Furnace 3
+induction-furnace-4=Induction Furnace 4
 
-casting-machine=Casting Machine MK1
-casting-machine-2=Casting Machine MK2
-casting-machine-3=Casting Machine MK3
-casting-machine-4=Casting Machine MK4
+casting-machine=Casting Machine 1
+casting-machine-2=Casting Machine 2
+casting-machine-3=Casting Machine 3
+casting-machine-4=Casting Machine 4
 
-ore-processing-machine=Ore Processing Machine MK1
-ore-processing-machine-2=Ore Processing Machine MK2
-ore-processing-machine-3=Ore Processing Machine MK3
-ore-processing-machine-4=Ore Processing Machine MK4
+ore-processing-machine=Ore Processing Machine 1
+ore-processing-machine-2=Ore Processing Machine 2
+ore-processing-machine-3=Ore Processing Machine 3
+ore-processing-machine-4=Ore Processing Machine 4
 
-pellet-press=Pellet Press MK1
-pellet-press-2=Pellet Press MK2
-pellet-press-3=Pellet Press MK3
-pellet-press-4=Pellet Press MK4
+pellet-press=Pellet Press 1
+pellet-press-2=Pellet Press 2
+pellet-press-3=Pellet Press 3
+pellet-press-4=Pellet Press 4
 
-sintering-oven=Sintering Oven MK1
-sintering-oven-2=Sintering Oven MK2
-sintering-oven-3=Sintering Oven MK3
-sintering-oven-4=Sintering Oven MK4
+sintering-oven=Sintering Oven 1
+sintering-oven-2=Sintering Oven 2
+sintering-oven-3=Sintering Oven 3
+sintering-oven-4=Sintering Oven 4
 
-strand-casting-machine=Strand Casting Machine MK1
-strand-casting-machine-2=Strand Casting Machine MK2
-strand-casting-machine-3=Strand Casting Machine MK3
-strand-casting-machine-4=Strand Casting Machine MK4
+strand-casting-machine=Strand Casting Machine 1
+strand-casting-machine-2=Strand Casting Machine 2
+strand-casting-machine-3=Strand Casting Machine 3
+strand-casting-machine-4=Strand Casting Machine 4
 
 cooling-tower=Cooling Tower
 


### PR DESCRIPTION
As refered in https://github.com/Arch666Angel/mods/issues/152, MK should be reserved for military items. All machines have been removed the MK//Mk prefix before numbering and adding missing number 1 for all machines with multiple tiers