### PR TITLE
Update angels-crystal-rock.lua to fix mod not loading with latest Factorio version

### DIFF
--- a/angelsrefining/prototypes/generation/angels-crystal-rock.lua
+++ b/angelsrefining/prototypes/generation/angels-crystal-rock.lua
@@ -4,7 +4,7 @@ data:extend(
       type = "simple-entity",
       name = "angels-crystal-rock",
       flags = {"placeable-neutral", "placeable-off-grid", "not-on-map"},
-      icon = "__base__/graphics/icons/rock-huge-icon.png",
+      icon = "__base__/graphics/icons/rock-huge.png",
       icon_size = 32,
       subgroup = "grass",
       order = "b[decorative]-k[stone-rock]-c[crystal]",


### PR DESCRIPTION
With the latest experimental version of Factorio, there is no __base__/graphics/icons/rock-huge-icon.png", instead there is a rock-huge.png
I saw it from there and having the same issue I tried to fix it: https://steamcommunity.com/app/427520/?l=czech&curator_clanid=4777282&utm_source=SteamDB