### PR TITLE
Bobs patch

### DIFF
--- a/angelsindustries/info.json
+++ b/angelsindustries/info.json
@@ -15,6 +15,7 @@
     "angelssmelting >= 0.6.7",
     "(?)bobtech >= 0.18.3",
     "(?)aai-industry >= 0.4.12",
-    "(?)bobrevamp >= 0.18.5"
+    "(?)bobrevamp >= 0.18.5",
+    "(?)bobassembly >= 0.18.6"
   ]
 }

--- a/angelsindustries/prototypes/overrides/global-tech-bobs-cores.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-bobs-cores.lua
@@ -10,7 +10,10 @@ if angelsmods.industries.tech then
     core_replace("grinding", "basic", "processing")
     core_replace("polishing", "basic", "processing")
     core_replace("mixing-furnace", "basic", "processing")
+    core_replace("steel-mixing-furnace", "basic", "processing")
     core_replace("electric-mixing-furnace", "basic", "processing")
+    core_replace("steel-chemical-furnace", "basic", "processing")
+    core_replace("electric-chemical-furnace", "basic", "processing")
     core_replace("gas-canisters", "basic", "processing")
     core_replace("ceramics", "basic", "processing")
 

--- a/angelsindustries/prototypes/overrides/global-tech-bobs-cores.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-bobs-cores.lua
@@ -9,7 +9,8 @@ if angelsmods.industries.tech then
     core_replace("electrolysis-2", "basic", "processing")
     core_replace("grinding", "basic", "processing")
     core_replace("polishing", "basic", "processing")
-    core_replace("mixing-steel-furnace", "basic", "processing")
+    core_replace("mixing-furnace", "basic", "processing")
+    core_replace("electric-mixing-furnace", "basic", "processing")
     core_replace("gas-canisters", "basic", "processing")
     core_replace("ceramics", "basic", "processing")
 
@@ -42,9 +43,9 @@ if angelsmods.industries.tech then
     end
     --oil-furnaces (and metal-mixing)
     if settings.startup["bobmods-assembly-oilfurnaces"].value then
-      core_replace("oil-steel-furnace", "basic", "processing")
-      core_replace("oil-mixing-steel-furnace", "basic", "processing")
-      core_replace("oil-chemical-steel-furnace", "basic", "processing")
+      core_replace("fluid-furnace", "logistic", "processing")
+      core_replace("fluid-mixing-furnace", "logistic", "processing")
+      core_replace("fluid-chemical-furnace", "logistic", "processing")
     end
     if settings.startup["bobmods-assembly-multipurposefurnaces"].value then
       core_replace("multi-purpose-furnace-1", "basic", "processing")

--- a/angelsindustries/prototypes/overrides/global-tech-bobs-packs.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-bobs-packs.lua
@@ -215,7 +215,7 @@ if angelsmods.industries.tech then
       pack_replace("bob-electric-energy-accumulators-2", "green", "orange")
     end
     if settings.startup["bobmods-power-fluidgenerator"].value == true then
-      pack_replace("fluid-generator-1", "green", "orange")
+      pack_replace("fluid-generator-1", "red", "orange")
     end
     if settings.startup["bobmods-power-steam"].value == true then
       pack_replace("bob-steam-engine-3", "green", "orange")

--- a/angelspetrochem/prototypes/global-override/bobassembly.lua
+++ b/angelspetrochem/prototypes/global-override/bobassembly.lua
@@ -134,6 +134,7 @@ if mods["bobplates"] then
   if angelsmods.trigger.disable_bobs_distilleries then
     angelsmods.functions.add_flag("bob-distillery", "hidden")
     angelsmods.functions.set_next_upgrade("assembling-machine", "bob-distillery", nil)
+    angelsmods.functions.set_next_upgrade("furnace", "bob-distillery", nil)
     OV.global_replace_item("bob-distillery", "angels-chemical-plant")
     OV.disable_recipe("bob-distillery")
     --OV.remove_unlock("bob-distillery")
@@ -147,6 +148,7 @@ if mods["bobplates"] then
     if angelsmods.trigger.disable_bobs_distilleries then
       angelsmods.functions.add_flag("bob-distillery-2", "hidden")
       angelsmods.functions.set_next_upgrade("assembling-machine", "bob-distillery-2", nil)
+      angelsmods.functions.set_next_upgrade("furnace", "bob-distillery-2", nil)
       OV.global_replace_item("bob-distillery-2", "angels-chemical-plant")
       OV.disable_recipe("bob-distillery-2")
       OV.disable_technology("bob-distillery-2")
@@ -159,6 +161,7 @@ if mods["bobplates"] then
     if angelsmods.trigger.disable_bobs_distilleries then
       angelsmods.functions.add_flag("bob-distillery-3", "hidden")
       angelsmods.functions.set_next_upgrade("assembling-machine", "bob-distillery-3", nil)
+      angelsmods.functions.set_next_upgrade("furnace", "bob-distillery-3", nil)
       OV.global_replace_item("bob-distillery-3", "angels-chemical-plant")
       OV.disable_recipe("bob-distillery-3")
       OV.disable_technology("bob-distillery-3")
@@ -171,6 +174,7 @@ if mods["bobplates"] then
     if angelsmods.trigger.disable_bobs_distilleries then
       angelsmods.functions.add_flag("bob-distillery-4", "hidden")
       angelsmods.functions.set_next_upgrade("assembling-machine", "bob-distillery-4", nil)
+      angelsmods.functions.set_next_upgrade("furnace", "bob-distillery-4", nil)
       OV.global_replace_item("bob-distillery-4", "angels-chemical-plant")
       OV.disable_recipe("bob-distillery-4")
       OV.disable_technology("bob-distillery-4")
@@ -183,6 +187,7 @@ if mods["bobplates"] then
     if angelsmods.trigger.disable_bobs_distilleries then
       angelsmods.functions.add_flag("bob-distillery-5", "hidden")
       angelsmods.functions.set_next_upgrade("assembling-machine", "bob-distillery-5", nil)
+      angelsmods.functions.set_next_upgrade("furnace", "bob-distillery-5", nil)
       OV.global_replace_item("bob-distillery-5", "angels-chemical-plant")
       OV.disable_recipe("bob-distillery-5")
       OV.disable_technology("bob-distillery-5")


### PR DESCRIPTION
Updated tech names
--no item changes were made
-fixed that bobs distilleries could be furnace of assembly machine (errored on furnace type next upgrade when hidden)
This works with the old version of the update bob made, so may want to hold off until the new one is actually released before pushing, just in case