### PR TITLE
Fix Science-Based Crafting Recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.zip
 *.dat
 mod-list.json
+.idea/

--- a/angelsindustries/changelog.txt
+++ b/angelsindustries/changelog.txt
@@ -4,6 +4,9 @@ Date: ??
   Changes:
     - Component mode:
       - Added a new battery component with intermediate parts (397)
+  Bugfixes:
+    - Science mode:
+      - Fixed that other mods' recipes which used science packs as ingredients were uncraftable
 ---------------------------------------------------------------------------------------------------
 Version: 0.4.6
 Date: 20.08.2020

--- a/angelsindustries/changelog.txt
+++ b/angelsindustries/changelog.txt
@@ -6,7 +6,7 @@ Date: ??
       - Added a new battery component with intermediate parts (397)
   Bugfixes:
     - Science mode:
-      - Fixed that other mods' recipes which used science packs as ingredients were uncraftable (398)
+      - Fixed that other mods' recipes which used science packs as ingredients were uncraftable (400)
 ---------------------------------------------------------------------------------------------------
 Version: 0.4.6
 Date: 20.08.2020

--- a/angelsindustries/changelog.txt
+++ b/angelsindustries/changelog.txt
@@ -6,7 +6,7 @@ Date: ??
       - Added a new battery component with intermediate parts (397)
   Bugfixes:
     - Science mode:
-      - Fixed that other mods' recipes which used science packs as ingredients were uncraftable
+      - Fixed that other mods' recipes which used science packs as ingredients were uncraftable (398)
 ---------------------------------------------------------------------------------------------------
 Version: 0.4.6
 Date: 20.08.2020

--- a/angelsindustries/prototypes/overrides/global-tech-base-cores.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-base-cores.lua
@@ -2,10 +2,6 @@ if angelsmods.industries.tech then
   local OV = angelsmods.functions.OV
   --require("prototypes.overrides.industries-override-functions")
 
-  -- now the custom fixes
-  OV.global_replace_technology("military-science-pack", "tech-green-packs")
-  OV.global_replace_technology("production-science-pack", "tech-blue-packs")
-
   -------------------------------------------------------------------------------
   -- NO CORES -------------------------------------------------------------------
   -------------------------------------------------------------------------------
@@ -123,6 +119,7 @@ if angelsmods.industries.tech then
   -------------------------------------------------------------------------------
   -- WARFARE CORES --------------------------------------------------------------
   -------------------------------------------------------------------------------
+  OV.global_replace_item("military-science-pack", "angels-science-pack-green") -- do this as it was not possible before
   -- BASE GAME
   for rec_4tech, _ in pairs(data.raw.technology) do --fix follower robot count techs
     if string.find(rec_4tech, "follower") ~= nil and string.find(rec_4tech, "robot") ~= nil then
@@ -131,9 +128,6 @@ if angelsmods.industries.tech then
   end
   --undo the change for the infinite tech (would normally be in with enhancement)
   core_replace("follower-robot-count-7", "war", "enhance")
-  OV.global_replace_item("military-science-pack", "angels-science-pack-green")
-  angelsmods.functions.add_flag("military-science-pack", "hidden")
-  OV.disable_recipe({"military-science-pack"})
   if mods["angelsexploration"] then
     core_replace("angels-bio-gun", "processing", "war")
     core_replace("angels-refined-biological-1", "processing", "war")
@@ -148,6 +142,7 @@ if angelsmods.industries.tech then
   -------------------------------------------------------------------------------
   -- PRODUCTION CORES -----------------------------------------------------------
   -------------------------------------------------------------------------------
+  OV.global_replace_item("production-science-pack", "angels-science-pack-yellow") -- do this as it was not possible before
   -- BASE GAME
   OV.set_science_pack("concrete", "datacore-processing-1", 2)
   OV.set_science_pack("circuit-network", "datacore-processing-1", 2)
@@ -169,9 +164,6 @@ if angelsmods.industries.tech then
   OV.set_science_pack("rubber", "datacore-processing-1", 2)
   core_replace("rocket-booster-1", "war", "processing")
   core_replace("rocket-booster-2", "war", "processing")
-  OV.global_replace_item("production-science-pack", "angels-science-pack-yellow")
-  angelsmods.functions.add_flag("production-science-pack", "hidden")
-  OV.disable_recipe({"production-science-pack"})
   OV.execute() ------------------------------------------------------------------
 
   -- now upgrade the cores to tier 2 and let them depend on the correct technology

--- a/angelsindustries/prototypes/overrides/global-tech-base-cores.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-base-cores.lua
@@ -131,6 +131,7 @@ if angelsmods.industries.tech then
   end
   --undo the change for the infinite tech (would normally be in with enhancement)
   core_replace("follower-robot-count-7", "war", "enhance")
+  OV.global_replace_item("military-science-pack", "angels-science-pack-green")
   angelsmods.functions.add_flag("military-science-pack", "hidden")
   OV.disable_recipe({"military-science-pack"})
   if mods["angelsexploration"] then
@@ -168,6 +169,7 @@ if angelsmods.industries.tech then
   OV.set_science_pack("rubber", "datacore-processing-1", 2)
   core_replace("rocket-booster-1", "war", "processing")
   core_replace("rocket-booster-2", "war", "processing")
+  OV.global_replace_item("production-science-pack", "angels-science-pack-yellow")
   angelsmods.functions.add_flag("production-science-pack", "hidden")
   OV.disable_recipe({"production-science-pack"})
   OV.execute() ------------------------------------------------------------------

--- a/angelsindustries/prototypes/overrides/global-tech-base-packs.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-base-packs.lua
@@ -42,11 +42,11 @@ if angelsmods.industries.tech then
   -------------------------------------------------------------------------------
   -- RED SCIENCE PACKS ----------------------------------------------------------
   -------------------------------------------------------------------------------
-  -- BASE GAME
   OV.global_replace_item("automation-science-pack", "angels-science-pack-red")
-  pack_replace("armor-making-2", "green", "red") --move armour making down a tier
   angelsmods.functions.add_flag("automation-science-pack", "hidden")
   OV.disable_recipe({"automation-science-pack"})
+  -- BASE GAME
+  pack_replace("armor-making-2", "green", "red") --move armour making down a tier
   pack_replace("automation-2", "green", "red")
   OV.remove_prereq("automation-2", "logistic-science-pack")
   -- SMELTING
@@ -82,12 +82,20 @@ if angelsmods.industries.tech then
   -------------------------------------------------------------------------------
   -- GREEN SCIENCE PACKS --------------------------------------------------------
   -------------------------------------------------------------------------------
-  -- BASE GAME
-  OV.global_replace_technology("logistic-science-pack", "tech-green-packs")
   OV.global_replace_item("logistic-science-pack", "angels-science-pack-green")
-  pack_replace("advanced-material-processing", "red", "green") --move advanced material processing up a tier
   angelsmods.functions.add_flag("logistic-science-pack", "hidden")
   OV.disable_recipe({"logistic-science-pack"})
+  OV.global_replace_technology("logistic-science-pack", "tech-green-packs")
+
+  --OV.global_replace_item("military-science-pack", "angels-science-pack-green") -- datacore replacement script needs to run first
+  angelsmods.functions.add_flag("military-science-pack", "hidden")
+  OV.disable_recipe({"military-science-pack"})
+  OV.global_replace_technology("military-science-pack", "tech-green-packs")
+  -- BASE GAME
+  pack_replace("advanced-material-processing", "red", "green") --move advanced material processing up a tier
+  pack_replace("lubricant", "blue", "green")
+  OV.remove_prereq("lubricant", "angels-advanced-oil-processing")
+  OV.add_prereq("lubricant", "angels-oil-processing")
   -- INDUSTRIES
   OV.add_prereq("angels-components-construction-3", "tech-green-packs")
   pack_replace("plastics", "orange", "green")
@@ -125,9 +133,6 @@ if angelsmods.industries.tech then
   pack_replace("bullet-damage-3", "green", "orange")
   pack_replace("flying", "green", "orange")
   pack_replace("robotics", "green", "orange")
-  pack_replace("lubricant", "blue", "orange")
-  OV.remove_prereq("lubricant", "angels-advanced-oil-processing")
-  OV.add_prereq("lubricant", "angels-oil-processing")
   OV.remove_science_pack("robotics", "angels-science-pack-blue")
   pack_replace("automated-construction", "green", "orange")
   OV.remove_science_pack("automated-construction", "angels-science-pack-blue")
@@ -171,14 +176,15 @@ if angelsmods.industries.tech then
   -------------------------------------------------------------------------------
   -- BLUE SCIENCE PACKS ---------------------------------------------------------
   -------------------------------------------------------------------------------
-  -- BASE GAME
-  OV.global_replace_technology("chemical-science-pack", "tech-blue-packs")
   OV.global_replace_item("chemical-science-pack", "angels-science-pack-blue")
+  angelsmods.functions.add_flag("chemical-science-pack", "hidden")
+  OV.disable_recipe({"chemical-science-pack"})
+  OV.global_replace_technology("chemical-science-pack", "tech-blue-packs")
+  -- BASE GAME
   OV.remove_science_pack("electric-engine", "angels-science-pack-blue")
   pack_replace("logistic-robotics", "green", "blue")
   pack_replace("electric-energy-distribution-2", "orange", "blue")
   angelsmods.functions.add_flag("chemical-science-pack", "hidden")
-  OV.disable_recipe({"chemical-science-pack"})
   -- INDUSTRIES
   pack_replace("angels-components-construction-5", "yellow", "blue")
   OV.remove_prereq("angels-components-construction-5", "utility-science-pack")
@@ -190,14 +196,19 @@ if angelsmods.industries.tech then
   -------------------------------------------------------------------------------
   -- YELOW SCIENCE PACKS --------------------------------------------------------
   -------------------------------------------------------------------------------
-  -- BASE GAME
-  OV.global_replace_technology("utility-science-pack", "tech-yellow-packs")
   OV.global_replace_item("utility-science-pack", "angels-science-pack-yellow")
   angelsmods.functions.add_flag("utility-science-pack", "hidden")
   OV.disable_recipe({"utility-science-pack"})
-  --REFINING
+  OV.global_replace_technology("utility-science-pack", "tech-yellow-packs")
+
+  --OV.global_replace_item("production-science-pack", "angels-science-pack-yellow")  -- datacore replacement script needs to run first
+  angelsmods.functions.add_flag("production-science-pack", "hidden")
+  OV.disable_recipe({"production-science-pack"})
+  OV.global_replace_technology("production-science-pack", "tech-yellow-packs")
+  -- BASE GAME
+  -- REFINING
   pack_replace("advanced-ore-refining-4", "blue", "yellow")
-  --ADDONS
+  -- ADDONS
   if mods["angelsaddons-warehouses"] then
     pack_replace("angels-logistic-warehouses", "blue", "yellow")
   end
@@ -208,8 +219,9 @@ if angelsmods.industries.tech then
   -------------------------------------------------------------------------------
   -- WHITE SCIENCE PACKS --------------------------------------------------------
   -------------------------------------------------------------------------------
-  -- BASE GAME
   OV.global_replace_item("space-science-pack", "angels-science-pack-white")
+  angelsmods.functions.add_flag("space-science-pack", "hidden")
+  -- BASE GAME
   OV.set_science_pack("rocket-silo", "angels-science-pack-grey")
   OV.set_science_pack("rocket-silo", "angels-science-pack-red")
   OV.set_science_pack("rocket-silo", "angels-science-pack-green")

--- a/angelsindustries/prototypes/overrides/global-tech-base-packs.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-base-packs.lua
@@ -43,6 +43,7 @@ if angelsmods.industries.tech then
   -- RED SCIENCE PACKS ----------------------------------------------------------
   -------------------------------------------------------------------------------
   -- BASE GAME
+  OV.global_replace_item("automation-science-pack", "angels-science-pack-red")
   pack_replace("armor-making-2", "green", "red") --move armour making down a tier
   angelsmods.functions.add_flag("automation-science-pack", "hidden")
   OV.disable_recipe({"automation-science-pack"})
@@ -83,6 +84,7 @@ if angelsmods.industries.tech then
   -------------------------------------------------------------------------------
   -- BASE GAME
   OV.global_replace_technology("logistic-science-pack", "tech-green-packs")
+  OV.global_replace_item("logistic-science-pack", "angels-science-pack-green")
   pack_replace("advanced-material-processing", "red", "green") --move advanced material processing up a tier
   angelsmods.functions.add_flag("logistic-science-pack", "hidden")
   OV.disable_recipe({"logistic-science-pack"})
@@ -171,6 +173,7 @@ if angelsmods.industries.tech then
   -------------------------------------------------------------------------------
   -- BASE GAME
   OV.global_replace_technology("chemical-science-pack", "tech-blue-packs")
+  OV.global_replace_item("chemical-science-pack", "angels-science-pack-blue")
   OV.remove_science_pack("electric-engine", "angels-science-pack-blue")
   pack_replace("logistic-robotics", "green", "blue")
   pack_replace("electric-energy-distribution-2", "orange", "blue")
@@ -189,6 +192,7 @@ if angelsmods.industries.tech then
   -------------------------------------------------------------------------------
   -- BASE GAME
   OV.global_replace_technology("utility-science-pack", "tech-yellow-packs")
+  OV.global_replace_item("utility-science-pack", "angels-science-pack-yellow")
   angelsmods.functions.add_flag("utility-science-pack", "hidden")
   OV.disable_recipe({"utility-science-pack"})
   --REFINING
@@ -205,6 +209,7 @@ if angelsmods.industries.tech then
   -- WHITE SCIENCE PACKS --------------------------------------------------------
   -------------------------------------------------------------------------------
   -- BASE GAME
+  OV.global_replace_item("space-science-pack", "angels-science-pack-white")
   OV.set_science_pack("rocket-silo", "angels-science-pack-grey")
   OV.set_science_pack("rocket-silo", "angels-science-pack-red")
   OV.set_science_pack("rocket-silo", "angels-science-pack-green")


### PR DESCRIPTION
Fix crafting recipes that used science as a crafting ingredient to use Angel's science packs as that crafting ingredient if tech overhaul is enabled, preventing them from being uncraftable. Resolves #398 