### PR TITLE
Fixed some bobclasses are not startable in some configurations (#394)

### DIFF
--- a/angelsrefining/changelog.txt
+++ b/angelsrefining/changelog.txt
@@ -12,6 +12,7 @@ Date: ??
     - Fixed localisation of ore refining descriptions (376)
     - Fixed crash with angels migration script library (383)
     - Fixed not being able to manually crush and processing trees with bob classes (366)
+    - Fixed some bobclasses are not startable in some configurations (394)
 ---------------------------------------------------------------------------------------------------
 Version: 0.11.16
 Date: 20.08.2020

--- a/angelsrefining/control.lua
+++ b/angelsrefining/control.lua
@@ -1,7 +1,13 @@
 script.on_init(function()
-  if remote.interfaces["freeplay"] then
+  if remote.interfaces["freeplay"] then -- give ore crushers
     local items_to_insert = remote.call("freeplay", "get_created_items")
     items_to_insert["burner-ore-crusher"] = (items_to_insert["burner-ore-crusher"] or 0) + 1
+    remote.call("freeplay", "set_created_items", items_to_insert)
+  end
+
+  if game.active_mods["bobclasses"] then -- give an extra miner
+    local items_to_insert = remote.call("freeplay", "get_created_items")
+    items_to_insert["burner-mining-drill"] = (items_to_insert["burner-mining-drill"] or 0) + 1 -- 2 additional plates
     remote.call("freeplay", "set_created_items", items_to_insert)
   end
 end)


### PR DESCRIPTION
Resolves #394 by giving an extra burner miner at the start of the game when playing with bob classes. There is no specific solution since there is no ability to specify for only which classes get the items, only a global setting to give to all bob classes.