### PR TITLE
Bob wood form coal fix (#379)

### DIFF
--- a/angelsinfiniteores/changelog.txt
+++ b/angelsinfiniteores/changelog.txt
@@ -3,6 +3,8 @@ Version: 0.9.5
 Date: ??
   Changes:
     - More localisation changes to unify angels localisation across mods (372)
+    - Removed bob's coal from wood when playing with angels infinite ores and angels bio processing
+      is present, as that would be an infinite source of coal as well (379)
 ---------------------------------------------------------------------------------------------------
 Version: 0.9.4
 Date: 17.07.2020

--- a/angelsinfiniteores/data-updates.lua
+++ b/angelsinfiniteores/data-updates.lua
@@ -1,3 +1,5 @@
+require "prototypes.infiniteores-override"
+
 -- EXECUTE OVERRIDES
 if not angelsmods.refining then
 	angelsmods.functions.update_autoplace()

--- a/angelsinfiniteores/prototypes/infiniteores-override.lua
+++ b/angelsinfiniteores/prototypes/infiniteores-override.lua
@@ -1,0 +1,1 @@
+require "prototypes.overrides.infiniteores-override-bobplates"

--- a/angelsinfiniteores/prototypes/overrides/infiniteores-override-bobplates.lua
+++ b/angelsinfiniteores/prototypes/overrides/infiniteores-override-bobplates.lua
@@ -1,0 +1,7 @@
+if mods["bobplates"] and mods["angelsbioprocessing"] then
+  -- there is an infinite wood production available, coal should
+  -- be obtained from infinite coal patches instead
+  local OV = angelsmods.functions.OV
+  OV.disable_recipe({"bob-coal-from-wood"})
+  OV.execute()
+end

--- a/angelspetrochem/settings-updates.lua
+++ b/angelspetrochem/settings-updates.lua
@@ -8,9 +8,9 @@ local function hide_setting(setting_type, setting_name, setting_default)
 end
 
 if mods["bobplates"] then
-  hide_setting("bool-setting", "angels-disable-vanilla-chemical-plants", false)
+  hide_setting("bool-setting", "angels-disable-vanilla-chemical-plants", true)
 else
-  hide_setting("bool-setting", "angels-disable-bobs-electrolysers", false)
-  hide_setting("bool-setting", "angels-disable-bobs-chemical-plants", false)
-  hide_setting("bool-setting", "angels-disable-bobs-distilleries", false)
+  hide_setting("bool-setting", "angels-disable-bobs-electrolysers", true)
+  hide_setting("bool-setting", "angels-disable-bobs-chemical-plants", true)
+  hide_setting("bool-setting", "angels-disable-bobs-distilleries", true)
 end

--- a/angelsrefining/changelog.txt
+++ b/angelsrefining/changelog.txt
@@ -12,6 +12,7 @@ Date: ??
     - Fixed localisation of ore refining descriptions (376)
     - Fixed crash with angels migration script library (383)
     - Fixed not being able to manually crush and processing trees with bob classes (366)
+    - Fixed some bobclasses are not startable in some configurations (394)
 ---------------------------------------------------------------------------------------------------
 Version: 0.11.16
 Date: 20.08.2020

--- a/angelsrefining/control.lua
+++ b/angelsrefining/control.lua
@@ -1,7 +1,13 @@
 script.on_init(function()
-  if remote.interfaces["freeplay"] then
+  if remote.interfaces["freeplay"] then -- give ore crushers
     local items_to_insert = remote.call("freeplay", "get_created_items")
     items_to_insert["burner-ore-crusher"] = (items_to_insert["burner-ore-crusher"] or 0) + 1
+    remote.call("freeplay", "set_created_items", items_to_insert)
+  end
+
+  if game.active_mods["bobclasses"] then -- give an extra miner
+    local items_to_insert = remote.call("freeplay", "get_created_items")
+    items_to_insert["burner-mining-drill"] = (items_to_insert["burner-mining-drill"] or 0) + 1 -- 2 additional plates
     remote.call("freeplay", "set_created_items", items_to_insert)
   end
 end)


### PR DESCRIPTION
Resolves #379: When angels infinite ore is present, and angels bio processing is also present, then infinite ore should provide the infinite ore patch, such that the coal from (infinite) wood is obsolete. In all other cases, it will still provide this recipe.