### PR TITLE
Make zinc oxide use chemical furnace - fixes inability to obtain.

### DIFF
--- a/angelssmelting/prototypes/recipes/smelting-zinc.lua
+++ b/angelssmelting/prototypes/recipes/smelting-zinc.lua
@@ -44,7 +44,7 @@ data:extend(
     {
       type = "recipe",
       name = "zinc-ore-processing-alt",
-      category = "ore-processing",
+      category = "chemical-smelting",
       subgroup = "angels-zinc",
       energy_required = 2,
       enabled = false,


### PR DESCRIPTION
Fix that battery one can't be obtained in components mode due to ore processors not having a fluid input.