### PR TITLE
Make description for overhaul settings more explicit

### DIFF
--- a/angelsindustries/changelog.txt
+++ b/angelsindustries/changelog.txt
@@ -2,6 +2,7 @@
 Version: 0.4.8
 Date: ??
   Bugfixes:
+    - Changed locales for settings and their description to make them more explicit
     - Regular mode:
       - Tweaked localisation of welcome message info (427)
     - Component mode:

--- a/angelsindustries/locale/en/logistic.cfg
+++ b/angelsindustries/locale/en/logistic.cfg
@@ -61,17 +61,17 @@ angels-ghosting-angels-construction-robots=This technology unlocks a toggle to e
 
 [mod-setting-name]
 angels-enable-industries=Industry overhaul
-angels-enable-components=Components overhaul
+angels-enable-components=Components overhaul (beta)
 angels-return-ingredients=Components overhaul – Mining components
 angels-components-stack-size=Components overhaul – Block stack size
-angels-enable-tech=Technology overhaul
+angels-enable-tech=Technology overhaul (alpha)
 
 [mod-setting-description]
 angels-enable-industries=Enables the overhaul intended by Angel's mods. Introduces many materials and processes known from Bob's mods.\n[img=utility/warning_icon] Auto-enabled when Bob's mods are present.
-angels-enable-components=[color=yellow][font=default-semibold]Beta[/font][/color]\n\nEnables electronics and construction components as intermediate products.\nBuildings become more complex to craft.\n[img=utility/warning_icon] Auto-enables the industry overhaul.
+angels-enable-components=Development status: [color=yellow][font=default-semibold]beta[/font][/color]\nEnables electronics and construction components as intermediate products.\nBuildings become more complex to craft.\n[img=utility/warning_icon] Auto-enables the industry overhaul.
 angels-return-ingredients=When enabled, buildings will return their ingredients on pick-up. Disabling this will return the building itself, as in vanilla.\n[img=utility/warning_icon] Auto-disabled when components are disabled.
 angels-components-stack-size=Stack size of the block components.\n[img=utility/warning_icon] Only affects gameplay with the components overhaul enabled
-angels-enable-tech=[color=yellow][font=default-semibold]Alpha[/font][/color]\nReworks the way technologies are researched. Different types of labs require different types of datacores and science analyzers.\n[img=utility/warning_icon] Auto-enables the components overhaul.
+angels-enable-tech=Development status: [color=yellow][font=default-semibold]alpha[/font][/color]\nReworks the way technologies are researched.\nDifferent types of labs require different types of datacores and science analyzers in order to progress.\n[img=utility/warning_icon] Auto-enables the components overhaul.
 
 [controls]
 toggle-ghosting=Toggle ghost creation on entity destruction

--- a/angelsindustries/locale/en/logistic.cfg
+++ b/angelsindustries/locale/en/logistic.cfg
@@ -60,18 +60,18 @@ angels-hidden-ghosting=Ghosted entities on destruction
 angels-ghosting-angels-construction-robots=This technology unlocks a toggle to enable and disable the creation of ghosts when entities are destroyed by external forces. By default the ghosting is enabled after researching it.
 
 [mod-setting-name]
-angels-enable-industries=Industry overhaul–Enable
-angels-enable-components=Components overhaul–Enable
-angels-return-ingredients=Components overhaul–Mining components
-angels-components-stack-size=Components overhaul–Block stack size
-angels-enable-tech=Technology overhaul–Enable
+angels-enable-industries=Industry overhaul
+angels-enable-components=Components overhaul
+angels-return-ingredients=Components overhaul – Mining components
+angels-components-stack-size=Components overhaul – Block stack size
+angels-enable-tech=Technology overhaul
 
 [mod-setting-description]
-angels-enable-industries=Enables the industry overhaul.\n[img=utility/warning_icon] Auto-enabled when bob mods are present.
-angels-enable-components=Enables electronics and construction components.\nBuildings become more complex to produce.\n[img=utility/warning_icon] Auto-enables the industry overhaul.
+angels-enable-industries=Enables the overhaul intended by Angel's mods. Introduces many materials and processes known from Bob's mods.\n[img=utility/warning_icon] Auto-enabled when Bob's mods are present.
+angels-enable-components=[color=yellow][font=default-semibold]Beta[/font][/color]\n\nEnables electronics and construction components as intermediate products.\nBuildings become more complex to craft.\n[img=utility/warning_icon] Auto-enables the industry overhaul.
 angels-return-ingredients=When enabled, buildings will return their ingredients on pick-up. Disabling this will return the building itself, as in vanilla.\n[img=utility/warning_icon] Auto-disabled when components are disabled.
 angels-components-stack-size=Stack size of the block components.\n[img=utility/warning_icon] Only affects gameplay with the components overhaul enabled
-angels-enable-tech=Enables the technology overhaul.\n[img=utility/warning_icon] Auto-enables the components overhaul.
+angels-enable-tech=[color=yellow][font=default-semibold]Alpha[/font][/color]\nReworks the way technologies are researched. Different types of labs require different types of datacores and science analyzers.\n[img=utility/warning_icon] Auto-enables the components overhaul.
 
 [controls]
 toggle-ghosting=Toggle ghost creation on entity destruction


### PR DESCRIPTION
Make description for overhaul settings more explicit.
Mark Component overhaul as beta explicitly.
Mark Technology overhaul as alpha explicitly.