### PR TITLE
Restore circuit network to red science tier, after electronics

### DIFF
--- a/angelsindustries/prototypes/overrides/global-tech-base-packs.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-base-packs.lua
@@ -60,6 +60,8 @@ if angelsmods.industries.tech then
   pack_replace("angels-components-construction-2", "green", "red")
   pack_replace("angels-components-cabling-2", "green", "red")
   pack_replace("angels-components-mechanical-2", "green", "red")
+  OV.remove_prereq("circuit-network", "tech-green-packs")
+  pack_replace("circuit-network", "green", "red")
 
   -------------------------------------------------------------------------------
   -- GREEN SCIENCE PACKS --------------------------------------------------------
@@ -78,7 +80,6 @@ if angelsmods.industries.tech then
   OV.add_prereq("angels-components-construction-3", "tech-green-packs")
   pack_replace("plastics", "orange", "green")
   pack_replace("battery", "orange", "green")
-  pack_replace("circuit-network", "orange", "green")
 
   -------------------------------------------------------------------------------
   -- ORANGE SCIENCE PACKS -------------------------------------------------------


### PR DESCRIPTION
The circuit network components only require red circuits, so I propose it should be red science tier and dependent only on electronics. This change restores circuit network to what I believe was its previous place when running with Angel's Industries tech (and no Bob's).