### PR TITLE
Fix low maximum output on thermal water extractors

### DIFF
--- a/angelsrefining/prototypes/buildings/ground-water-pump.lua
+++ b/angelsrefining/prototypes/buildings/ground-water-pump.lua
@@ -49,7 +49,7 @@ data:extend(
       pumping_speed = 20/1200 * 60,
       fluid_box =
       {
-        base_area = 1,
+        base_area = 10,
         base_level = 1,
         pipe_covers = pipecoverspictures(),
         production_type = "output",

--- a/angelsrefining/prototypes/buildings/thermal-extractor.lua
+++ b/angelsrefining/prototypes/buildings/thermal-extractor.lua
@@ -43,7 +43,7 @@ data:extend(
         usage_priority = "secondary-input"
       },
       output_fluid_box = {
-        base_area = 1,
+        base_area = 10,
         base_level = 1,
         pipe_covers = pipecoverspictures(),
         pipe_connections =


### PR DESCRIPTION
See  #https://github.com/Arch666Angel/mods/issues/509

Thermal water extractors can only output 100 units of fluid per operation due to only having an internal fluid buffer of 100 units. This is extremely low, both compared to the actual richness levels that fissures can generate at and also just compared to pumpjacks which have a buffer of 1000 units. Given the richness of wells (assuming it's not just a really, really buggy interaction with RSO) it's possible that this number should be significantly higher but at a minimum increasing the number to match pumpjacks should be fairly uncontroversial.