### PR TITLE
Fix recipe generation for non-deterministic pairs()

### DIFF
--- a/angelsrefining/prototypes/override-functions.lua
+++ b/angelsrefining/prototypes/override-functions.lua
@@ -805,8 +805,8 @@ local function adjust_recipe(recipe, k) -- check a recipe for basic adjustments 
           item.name = new
         end
         if replace[item.name] then
-          if item.probability then
-            if replace[item.name].probability and replace[item.name].probability ~= item.probability then
+          if item.probability or replace[item.name].probability then
+            if item.probability and replace[item.name].probability and replace[item.name].probability ~= item.probability then
               --update probability if it exists in both cases
               replace[item.name].probability = item.probability
             else

--- a/angelsrefining/prototypes/override/refining-override-sorting.lua
+++ b/angelsrefining/prototypes/override/refining-override-sorting.lua
@@ -261,7 +261,11 @@ local create_sorting_recipes = function(refinery_product, recipe_base_name, sort
           if ore_amount then
             table.insert(recipe.results, {"!!"})
           end
-        else
+        end
+      end
+      for ore_name, ore_amounts in pairs(sorted_ore_results or {}) do
+        local ore_amount = (ore_amounts or {})[tier]
+        if ore_name ~= "!!" then
           if not angelsmods.trigger.ores[get_trigger_name[ore_name] or ore_name] then
             ore_amount = 0
           end

--- a/angelsrefining/prototypes/recipe-builder.lua
+++ b/angelsrefining/prototypes/recipe-builder.lua
@@ -419,7 +419,7 @@ local function p_merge_item_lists(base, patch)
          add(n, t, a)
          adjust_secondary_atts(n, t, item)
       end
-      for _, item in pairs(patch) do
+      for _, item in ipairs(patch) do
          local n, t, a, o = item.name or item[1], item.type or "item", item.amount or item[2]
          if n == "!!" then
             clear()


### PR DESCRIPTION
# Summary

If `pairs()` is non-deterministic (as in standard lua, as opposed to Factorio's lua runtime), invalid recipes are generated. In particular, this affects [YAFC](https://github.com/ShadowTheAge/yafc).

# Steps to reproduce

I unpacked a fresh Factorio 1.1.19 and installed SeaBlock 0.5.2 (which pulls in angelsbioprocessing_0.7.17, angelspetrochem_0.9.17, angelsrefining, angelsrefining_0.11.19, angelssmelting_0.6.14, A Sea Block Config_0.5.1, bobelectronics_1.1.3, boblibrary_1.1.2, boblogistics_1.1.2, bobplates_1.1.2). Afterwards I applied a fix to SeaBlock (see KiwiHawk/SeaBlock#95).

(I have also verified that the behaviour described below occurs when using the upstream version of angelsrefining, 21593d7 .)

Then I installed the upstream version of YAFC (commit ShadowTheAge/yafc@72dd28105f69cb2892d6b2055b2158b57e9e846d , version 0.5.4.1) and pointed it towards the aforementioned Factorio install. This will complain that things are inaccessible, which is fine. However, certain recipes are wrong, in a non-deterministic manner. (So they will be wrong sometimes, and sometimes not.)

- Crafting seeds from dormant seeds (all types) should result in 5x seeds and 5% seeds (i.e. an expected value of 5.05 total). For some recipes the results are 5x 5% seeds instead (i.e. an expected value of 0.25 total). As mentioned, sometimes a recipe might be correct, but at least one should be wrong most of the time.
- Some ore sorting recipes are missing results. This occurs mostly in sorting recipes with lots of outputs, e.g. purified or ferrous/cupric crystals. Again, some of the recipes might be correct, but it is usually not difficult to find ones that are wrong.

# Details

Factorio uses a modified version of `pairs()` which iterates integer keys (up to 1024) in order and then iterates the other keys in insertion order. The standard lua runtime makes no such guarantees. The recipe overwriting code relies on the behaviour of the former, which works perfectly fine in the context of Factorio itself, but breaks YAFC.

I have attached a quick fix for the two problematic types of recipes from above. I will also file an issue on the YAFC repository, but I suspect that this is harder to fix from their side.