### PR TITLE
Fixed that gun-turret technology did not depend on military (549)

### DIFF
--- a/angelsexploration/changelog.txt
+++ b/angelsexploration/changelog.txt
@@ -3,6 +3,7 @@ Version: 0.3.10
 Date: ??
   Bugfixes:
     - Fixed collision box and drawing box of the mammoth heavy tank (476)
+    - Fixed that turret technology did not depend on military (549)
 ---------------------------------------------------------------------------------------------------
 Version: 0.3.9
 Date: 26.11.2020

--- a/angelsexploration/prototypes/exploration-override.lua
+++ b/angelsexploration/prototypes/exploration-override.lua
@@ -30,7 +30,7 @@ if angelsmods.industries then
         }
       }
     )
-    OV.add_prereq("turrets", "military")
+    OV.add_prereq("gun-turret", "military")
 
     if bobmods and bobmods.warfare then
       -- sniper turret


### PR DESCRIPTION
Fixed that internal technology re-naming from vanilla was not properly accounted for, resulting in gun-turret not depending on military. See #549 