### PR TITLE
Adjust starting items for Bob's characters

### DIFF
--- a/angelsrefining/changelog.txt
+++ b/angelsrefining/changelog.txt
@@ -26,6 +26,7 @@ Date: ??
     - Improved the limited flow capacity in the Thermal bore/extractor (509)
     - Fixed an issue with Yuoki's icons not being updated (with the old ones already removed)
     - Fixed that the method for removing autoplace controls was not universally used (373)
+    - Fixed deadlock for bobclasses "fighter" and component mode (394, 559)
 ---------------------------------------------------------------------------------------------------
 Version: 0.11.19
 Date: 26.11.2020

--- a/angelsrefining/control.lua
+++ b/angelsrefining/control.lua
@@ -5,9 +5,9 @@ script.on_init(function()
     remote.call("freeplay", "set_created_items", items_to_insert)
   end
 
-  if game.active_mods["bobclasses"] and remote.interfaces['freeplay'] then -- give an extra miner
+  if game.active_mods["bobclasses"] and remote.interfaces['freeplay'] then -- give additional plates
     local items_to_insert = remote.call("freeplay", "get_created_items")
-    items_to_insert["burner-mining-drill"] = (items_to_insert["burner-mining-drill"] or 0) + 1 -- 2 additional plates
+    items_to_insert["iron-plate"] = (items_to_insert["iron-plate"] or 0) + 2 -- 2 additional plates
     remote.call("freeplay", "set_created_items", items_to_insert)
   end
 end)

--- a/angelsrefining/control.lua
+++ b/angelsrefining/control.lua
@@ -1,16 +1,18 @@
-local technology_overhaul = settings.startup["angels-enable-tech"].value
-local components_overhaul = technology_overhaul or settings.startup["angels-enable-components"].value
-
 script.on_init(function()
-  if remote.interfaces["freeplay"] then -- give ore crushers
+  if remote.interfaces["freeplay"] then
     local items_to_insert = remote.call("freeplay", "get_created_items")
+    local technology_overhaul = settings.startup["angels-enable-tech"].value
+    local components_overhaul = technology_overhaul or settings.startup["angels-enable-components"].value
+    
+    -- give ore crushers
     items_to_insert["burner-ore-crusher"] = (items_to_insert["burner-ore-crusher"] or 0) + 1
-    remote.call("freeplay", "set_created_items", items_to_insert)
-  end
-
-  if game.active_mods["bobclasses"] and components_overhaul and remote.interfaces['freeplay'] then -- give additional plates
-    local items_to_insert = remote.call("freeplay", "get_created_items")
-    items_to_insert["iron-plate"] = (items_to_insert["iron-plate"] or 0) + 2 -- 2 additional plates
+    if game.active_mods["bobclasses"] then
+      -- fix character classes starting point
+      if components_overhaul then
+	-- give two additional iron plates
+        items_to_insert["iron-plate"] = (items_to_insert["iron-plate"] or 0) + 2
+      end
+    end
     remote.call("freeplay", "set_created_items", items_to_insert)
   end
 end)

--- a/angelsrefining/control.lua
+++ b/angelsrefining/control.lua
@@ -1,3 +1,6 @@
+local technology_overhaul = settings.startup["angels-enable-tech"].value
+local components_overhaul = technology_overhaul or settings.startup["angels-enable-components"].value
+
 script.on_init(function()
   if remote.interfaces["freeplay"] then -- give ore crushers
     local items_to_insert = remote.call("freeplay", "get_created_items")
@@ -5,7 +8,7 @@ script.on_init(function()
     remote.call("freeplay", "set_created_items", items_to_insert)
   end
 
-  if game.active_mods["bobclasses"] and remote.interfaces['freeplay'] then -- give additional plates
+  if game.active_mods["bobclasses"] and components_overhaul and remote.interfaces['freeplay'] then -- give additional plates
     local items_to_insert = remote.call("freeplay", "get_created_items")
     items_to_insert["iron-plate"] = (items_to_insert["iron-plate"] or 0) + 2 -- 2 additional plates
     remote.call("freeplay", "set_created_items", items_to_insert)


### PR DESCRIPTION
Do not merge yet.

A first attempt to adjust starting items for Bob's Character classes.
Currently, the fix for #394 does not work as it should.
Fighter class with Angel's Component Overhaul cannot make a first stone furnace.

However, this should only be executed with Component Overhaul, but
`if game.active_mods["bobclasses"] and angelsmods.industries.components and remote.interfaces['freeplay']`
does not appear to work inside `on_init`