### PR TITLE
Resin and rubber technologies disabled when bobelectronics isn't loaded

### DIFF
--- a/angelspetrochem/migrations/angelspetrochem_0.9.18.lua
+++ b/angelspetrochem/migrations/angelspetrochem_0.9.18.lua
@@ -1,0 +1,18 @@
+for _, force in pairs(game.forces) do
+	force.reset_recipes()
+	force.reset_technologies()
+	force.reset_technology_effects()
+	local nobobelectronics = true
+	for name, _ in pairs(game.active_mods) do
+		if name == "bobelectronics" then nobobelectronics = false
+		end
+	end
+	if nobobelectronics == true then
+		force.technologies["resin-1"].enabled = false
+		force.technologies["resin-2"].enabled = false
+		force.technologies["resin-3"].enabled = false
+		force.technologies["resins"].enabled = false
+		force.technologies["rubber"].enabled = false
+		force.technologies["rubbers"].enabled = false
+	end
+end

--- a/angelspetrochem/prototypes/override/bobelectronics.lua
+++ b/angelspetrochem/prototypes/override/bobelectronics.lua
@@ -1,5 +1,14 @@
 local OV = angelsmods.functions.OV
 
 if not mods["bobelectronics"] then
+	--disable empty resin technologies
 	OV.disable_technology({"resin-1", "resin-2", "resin-3"})
+	--disable resins and remove from cement-processing-2
+	OV.disable_technology("resins")
+	OV.remove_prereq("angels-stone-smelting-2","resins")
+	angelsmods.functions.disable_barreling_recipes("liquid-resin")	
+	----
+	--rubbers
+	OV.disable_technology({"rubber", "rubbers"})
+	angelsmods.functions.disable_barreling_recipes("liquid-rubber")
 end

--- a/angelspetrochem/prototypes/override/bobelectronics.lua
+++ b/angelspetrochem/prototypes/override/bobelectronics.lua
@@ -1,0 +1,5 @@
+local OV = angelsmods.functions.OV
+
+if not mods["bobelectronics"] then
+	OV.disable_technology({"resin-1", "resin-2", "resin-3"})
+end

--- a/angelspetrochem/prototypes/petrochem-override.lua
+++ b/angelspetrochem/prototypes/petrochem-override.lua
@@ -18,7 +18,7 @@ require("prototypes.override.bobplates")
 require("prototypes.override.bobassembly")
 require("prototypes.override.bobgreenhouse")
 require("prototypes.override.boblogistics")
-
+require("prototypes.override.bobelectronics")
 --UPDATE ENTITY RECIPES
 require("prototypes.recipes.petrochem-entity-angels")
 


### PR DESCRIPTION
Resolves #446
Disables resin and rubber technologies when there is no bobelectronics.
Looks like disabling technology does not trigger an auto-migration. Migration script should fix it. Although, if technology already researched, it remains enabled.