### PR TITLE
Deactivate burner power phase overrides from Angel's petrochem

### DIFF
--- a/angelspetrochem/prototypes/global-override/bobtech.lua
+++ b/angelspetrochem/prototypes/global-override/bobtech.lua
@@ -4,7 +4,5 @@ local OV = angelsmods.functions.OV
 -- STEAM BURNER PHASE ---------------------------------------------------------
 -------------------------------------------------------------------------------
 if mods["bobtech"] and settings.startup["bobmods-burnerphase"].value then
-  OV.add_prereq("basic-chemistry", "ore-crushing")
-
-  OV.add_prereq("angels-fluid-control", "steel-processing")
+  --do nothing
 end

--- a/angelspetrochem/prototypes/petrochem-global-override.lua
+++ b/angelspetrochem/prototypes/petrochem-global-override.lua
@@ -27,7 +27,7 @@ require("prototypes.global-override.bobplates")
 require("prototypes.global-override.bobrevamp")
 require("prototypes.global-override.bobwarfare")
 require("prototypes.global-override.bobassembly")
-require("prototypes.global-override.bobtech")
+--require("prototypes.global-override.bobtech")
 require("prototypes.global-override.bobgreenhouse")
 require("prototypes.global-override.boblogistics")
 

--- a/angelspetrochem/prototypes/petrochem-global-override.lua
+++ b/angelspetrochem/prototypes/petrochem-global-override.lua
@@ -27,7 +27,7 @@ require("prototypes.global-override.bobplates")
 require("prototypes.global-override.bobrevamp")
 require("prototypes.global-override.bobwarfare")
 require("prototypes.global-override.bobassembly")
---require("prototypes.global-override.bobtech")
+require("prototypes.global-override.bobtech")
 require("prototypes.global-override.bobgreenhouse")
 require("prototypes.global-override.boblogistics")
 


### PR DESCRIPTION
Bob's burner power phase introduces additional technologies and dependencies for the earliest game stage.
The overrides that were used to ensure compatibility between angel's petrochem and bob's burner power phase are no longer required. This PR deactivates these overrides from Angel's petrochem.