### PR TITLE
Fix numeral scaling for icon_layers without scale specification

### DIFF
--- a/angelsrefining/prototypes/angels-functions.lua
+++ b/angelsrefining/prototypes/angels-functions.lua
@@ -5,19 +5,19 @@ local function get_icons(object_name)
   for _, prototype in pairs({"item", "fluid", "ammo", "capsule"}) do
     local object = data.raw[prototype][object_name]
     if object then
+      if object.icons then -- icons has precedence over icon
+        return object.icons
+      end
       if object.icon then
-        local scale = 32 / (object.icon_size or 32)
+        -- local scale = 32 / (object.icon_size or 32)
         return {
           {
             icon = object.icon,
             icon_size = object.icon_size or 32,
             icon_mipmaps = object.icon_mipmaps ~= 1 and object.icon_mipmaps or nil,
-            scale = scale ~= 1 and scale or nil
+            scale = 32 / (object.icon_size or 32)
           }
         }
-      end
-      if object.icons then
-        return object.icons
       end
     end
   end
@@ -113,31 +113,31 @@ end
 function angelsmods.functions.add_number_icon_layer(icon_layers, number_tier, number_tint, outline_tint)
   -- adds a new layer to icon_layers to show the tier number (with a color)
   -- outline_tint is optional
-  local icon_size_scale = 1
+  local icon_size_scale = 0.5
   local icon_size_shift = {0, 0}
 
   icon_layers = icon_layers or {}
   if #icon_layers == 0 then
     -- if the icon_layer is empty, we make sure it will be a full sized number after usage in the recipe functions
-    icon_size_scale = 32 / 10.24
-    icon_size_shift = {11.5 * icon_size_scale, 12 * icon_size_scale}
-  else
-    icon_size_scale = (icon_layers[1].icon_size or 32) * (icon_layers[1].scale or 1) / 32
-  end 
-  
+    icon_size_scale = 0.5 * 32 / 10.24
+    icon_size_shift = {11.5 * icon_size_scale * 2, 12 * icon_size_scale * 2}
+  elseif icon_layers[1].scale then
+    icon_size_scale = (icon_layers[1].icon_size or 32) * (icon_layers[1].scale) / 64
+  end
+
   return angelsmods.functions.add_icon_layer(icon_layers, {
     {
       icon = "__angelsrefining__/graphics/icons/numerals/num-"..number_tier.."-outline.png",
       icon_size = 64, icon_mipmaps = 2,
       tint = unify_tint(outline_tint or {0, 0, 0, 1}),
-      scale = 0.5 * icon_size_scale,
+      scale = icon_size_scale,
       shift = icon_size_shift
     },
     {
       icon = "__angelsrefining__/graphics/icons/numerals/num-"..number_tier..".png",
       icon_size = 64, icon_mipmaps = 2,
       tint = unify_tint(number_tint),
-      scale = 0.5 * icon_size_scale,
+      scale = icon_size_scale,
       shift = icon_size_shift
     }
   })
@@ -169,7 +169,7 @@ local icon_tint_table = {
 local function create_recipe_molecule_icons(molecules_icon, molecules_shift, molecules_scale)
   molecules_icon = clean_table(molecules_icon) or {}
   molecules_shift = molecules_shift or {{-11.5, 12}, {11.5, 12}, {0, 12}}
-  molecules_scale = molecules_scale or 10.24 / 32 -- assume base 32 size
+  molecules_scale = molecules_scale or (10.24 / 32) -- assume base 32 size
 
   for molecule_index, molecule_icon in pairs(molecules_icon) do
     if type(molecule_icon) ~= "table" and get_icons(molecule_icon) ~= "__angelsrefining__/graphics/icons/void.png" then
@@ -1053,7 +1053,7 @@ function angelsmods.functions.add_flag(entity, flag) -- Adds a flag to an item/f
     end
     return
   end
-  
+
   for _,type in pairs({"item","tool","item-with-entity-data","fluid"}) do --list of things to hide
     local to_add = data.raw[type][entity] or nil
     if to_add then
@@ -1182,7 +1182,7 @@ function angelsmods.functions.create_barreling_fluid_subgroup(fluids_to_move)
 
   local items = data.raw.item
   local recipes = data.raw.recipe
-  
+
   if not fluids_to_move or #fluids_to_move == 0 then
     fluids_to_move = data.raw.fluid
   end
@@ -1490,7 +1490,7 @@ function angelsmods.functions.add_crafting_category(crafting_machine_type, craft
 
   local crafting_machine_prototype = data.raw[crafting_machine_type][crafting_machine_name]
   crafting_machine_prototype.crafting_categories = crafting_machine_prototype.crafting_categories or {}
-  
+
   for _, category_name in pairs(crafting_machine_prototype.crafting_categories) do
     if category_name == crafting_category then
       return -- already present
@@ -1498,7 +1498,7 @@ function angelsmods.functions.add_crafting_category(crafting_machine_type, craft
   end
 
   table.insert(crafting_machine_prototype.crafting_categories, crafting_category)
-  
+
   if crafting_category ~= "angels-unused-machine" then
     angelsmods.functions.remove_crafting_category(crafting_machine_type, crafting_machine_name, "angels-unused-machine")
   end
@@ -1520,7 +1520,7 @@ function angelsmods.functions.remove_crafting_category(crafting_machine_type, cr
   for category_index, category_name in pairs(crafting_machine_categories) do
     if category_name == crafting_category then
       table.remove(crafting_machine_categories, category_index)
-      
+
       if next(crafting_machine_categories) then
         return
       else


### PR DESCRIPTION
1. Adjusted precendence for icons vs icon, moved return icons above return icon in function get_icons()
2. Baked 0.5 scaling factor into icon_size_scale calculation for instances where scale is specified, and where it is not, icon_size_scale is 0.5.
3. Added brackets around 10.24 / 32 on line 172 to make parser happy
4. Cleaned up trailing whitespace