### PR TITLE
Removes kovarex as prereq for plutonium-synthesis research

### DIFF
--- a/angelsindustries/prototypes/overrides/overhaul-nuclear-power.lua
+++ b/angelsindustries/prototypes/overrides/overhaul-nuclear-power.lua
@@ -146,6 +146,7 @@ if angelsmods.industries.overhaul then
       "a[radioactive-element]-e[plutonium-239]"
     )
     angelsmods.functions.add_flag("plutonium-240", "hidden")
+    OV.remove_prereq("plutonium-synthesis", "kovarex-enrichment-process")
 
     -- plutonium enrichment process
     if mods["bobrevamp"] and settings.startup["bobmods-revamp-rtg"].value then


### PR DESCRIPTION
This removes the `kovarex-enrichment-process` research as a prerequisite for the `plutonium-synthesis`. See #601  
It keeps the research itself enabled, to not break compatibility with other mods. It does not unlock any new recipes, though.