### PR TITLE
Do not re-add solid-fuel-from-hydrogen

### DIFF
--- a/angelspetrochem/prototypes/global-override/bobrevamp.lua
+++ b/angelspetrochem/prototypes/global-override/bobrevamp.lua
@@ -33,7 +33,7 @@ if mods["bobrevamp"] then
     OV.remove_unlock("angels-oil-processing", "solid-fuel-from-hydrogen")
 
     OV.add_unlock("flammables", "liquid-fuel")
-    OV.add_unlock("flammables", "solid-fuel-from-hydrogen")
+    --OV.add_unlock("flammables", "solid-fuel-from-hydrogen")
     OV.add_unlock("flammables", "enriched-fuel-from-liquid-fuel")
 
     OV.add_prereq("chemical-processing-3", "flammables")


### PR DESCRIPTION
This PR prevents the petrochem override for bobrevamp from re-adding `solid-fuel-from-hydrogen` to the `flammables` technology.
This fixes #618 