### PR TITLE
Fixing an issue with Exploration Lab 2 and not having Alien Specimen slot

### DIFF
--- a/angelsindustries/prototypes/buildings/angels-labs-exploration.lua
+++ b/angelsindustries/prototypes/buildings/angels-labs-exploration.lua
@@ -130,7 +130,8 @@ if angelsmods.industries.tech then
             create_rich_text_icons {
               "angels-science-pack-blue",
               "angels-science-pack-yellow",
-              "datacore-exploration-2"
+              "datacore-exploration-2",
+              "token-bio"
             }
           }
         },
@@ -175,7 +176,8 @@ if angelsmods.industries.tech then
         inputs = {
           "angels-science-pack-blue",
           "angels-science-pack-yellow",
-          "datacore-exploration-2"
+          "datacore-exploration-2",
+          "token-bio"
         },
         module_specification = {
           module_slots = 2,


### PR DESCRIPTION
there is an issue that this lab (Exploration lab 2) didnt have alien specimen slots, and you couldnt continue the puffer tree with out it. (starting at Puffer Refugium 2 and more onward). This puts that into the lab both in the help area for the machine and the machine itself.