### PR TITLE
Unit test failures

### DIFF
--- a/angelsdev-unit-test/unit-tests/unit-test-003.lua
+++ b/angelsdev-unit-test/unit-tests/unit-test-003.lua
@@ -10,6 +10,7 @@ local products_to_ignore =
 {
   ["chemical-void"] = true,
   ["water-void"] = true,
+  ["void"] = true -- Bob's void
 }
 
 local unit_test_003 = function()

--- a/angelsdev-unit-test/unit-tests/unit-test-004.lua
+++ b/angelsdev-unit-test/unit-tests/unit-test-004.lua
@@ -49,6 +49,7 @@ local unit_test_004 = function()
     tech_unlocked_by_script["sb-startup1"] = true
     tech_unlocked_by_script["sb-startup2"] = true
     tech_unlocked_by_script["sb-startup3"] = true
+    tech_unlocked_by_script["sb-startup4"] = true
     tech_unlocked_by_script["sct-automation-science-pack"] = true
   end
 

--- a/angelsdev-unit-test/unit-tests/unit-test-006.lua
+++ b/angelsdev-unit-test/unit-tests/unit-test-006.lua
@@ -147,6 +147,7 @@ local function calculate_science_pack_level()
     technologies_to_ignore["spaceship-command"] = true
     technologies_to_ignore["astrometrics"] = true
     technologies_to_ignore["ftl-theory-A"] = true
+    technologies_to_ignore["ftl-propulsion"] = true
   end
 end
 

--- a/angelspetrochem/prototypes/global-override/bobrevamp.lua
+++ b/angelspetrochem/prototypes/global-override/bobrevamp.lua
@@ -32,9 +32,7 @@ if mods["bobrevamp"] then
     OV.remove_unlock("angels-oil-processing", "liquid-fuel")
     OV.remove_unlock("angels-oil-processing", "solid-fuel-from-hydrogen")
 
-    OV.add_unlock("flammables", "liquid-fuel")
     --OV.add_unlock("flammables", "solid-fuel-from-hydrogen")
-    OV.add_unlock("flammables", "enriched-fuel-from-liquid-fuel")
 
     OV.add_prereq("chemical-processing-3", "flammables")
 

--- a/angelspetrochem/prototypes/override/bobplates.lua
+++ b/angelspetrochem/prototypes/override/bobplates.lua
@@ -152,8 +152,8 @@ if mods["bobplates"] then
       }
     }
   )
-  OV.add_unlock("angels-oil-processing", "liquid-fuel")
-
+    OV.add_unlock("flammables", "liquid-fuel")
+    OV.add_unlock("flammables", "enriched-fuel-from-liquid-fuel")
 end
 
 -------------------------------------------------------------------------------

--- a/angelspetrochem/prototypes/override/bobplates.lua
+++ b/angelspetrochem/prototypes/override/bobplates.lua
@@ -152,8 +152,8 @@ if mods["bobplates"] then
       }
     }
   )
-    OV.add_unlock("flammables", "liquid-fuel")
-    OV.add_unlock("flammables", "enriched-fuel-from-liquid-fuel")
+  OV.add_unlock("flammables", "liquid-fuel")
+  OV.add_unlock("flammables", "enriched-fuel-from-liquid-fuel")
 end
 
 -------------------------------------------------------------------------------

--- a/angelsrefining/info.json
+++ b/angelsrefining/info.json
@@ -12,6 +12,7 @@
     "? bobplates >= 0.18.8",
     "? bobrevamp >= 0.18.5",
     "(?) bobmodules >= 0.18.0",
+    "(?) boblogistics",
     "? rso-mod >= 2.3.3",
     "? Yuoki >= 0.4.0",
     "? UraniumPower >= 0.6.4",


### PR DESCRIPTION
### Bob repair packs unit test failure

Bob's mods being loaded after Angel's. Angel's override is being overwritten by Bob's.
[angelsrefining\prototypes\override\refining-override-boblogistics](https://github.com/Arch666Angel/mods/blob/dev/angelsrefining/prototypes/override/refining-override-boblogistics.lua)


### Enriched fuel block unit test failure
Recipe `enriched-fuel-from-liquid-fuel` cannot be unlocked by research.
With `bobplates` and `bobrevamp`, this recipe (and `liquid-fuel`) will be unlocked by `flammables`.
With just `bobplates`, this recipe has no unlock tech. Recipe `liquid-fuel` will  be unlocked by `angels-oil-processing`

