### PR TITLE
Advanced Gas Processing prerequisite

### DIFF
--- a/angelspetrochem/prototypes/technology/petrochem-petro-chemistry.lua
+++ b/angelspetrochem/prototypes/technology/petrochem-petro-chemistry.lua
@@ -161,8 +161,7 @@ data:extend(
       icon = "__angelspetrochem__/graphics/technology/advanced-gas-refinery-tech.png",
       icon_size = 256, icon_mipmaps = 2,
       prerequisites = {
-        "gas-processing",
-        "chemical-science-pack"
+        "gas-steam-cracking-2"
       },
       effects = {
         {
@@ -323,7 +322,6 @@ data:extend(
         "angels-advanced-chemistry-2",
         "advanced-electronics-2",
         "angels-advanced-gas-processing",
-        "gas-steam-cracking-2",
         "oil-steam-cracking-2"
       },
       effects = {


### PR DESCRIPTION
Make Advanced Gas Processing Depend on Gas Steam Cracking 2 (for Syngas)
Advanced Chemistry now no longer needs to depend on Gas Steam Cracking 2 as it also depends on Advanced Gas Processing.

Resolves #804