### PR TITLE
Unused component blocks

### DIFF
--- a/angelsindustries/data.lua
+++ b/angelsindustries/data.lua
@@ -8,8 +8,20 @@ angelsmods.industries.tech_exceptions = angelsmods.industries.tech_exceptions or
 angelsmods.industries.tech = settings.startup["angels-enable-tech"].value -- enable technology overhaul
 
 angelsmods.industries.components = settings.startup["angels-enable-components"].value
+angelsmods.industries.blocks = angelsmods.industries.blocks or {}
+angelsmods.industries.blocks.exploration = false
+angelsmods.industries.blocks.logistic = false
+angelsmods.industries.blocks.warfare = false
+angelsmods.industries.blocks.enhancement5 = false
+angelsmods.industries.blocks.energy5 = false
+
 if angelsmods.industries.tech == true then
   angelsmods.industries.components = true
+  angelsmods.industries.blocks.exploration = true
+  angelsmods.industries.blocks.logistic = true
+  angelsmods.industries.blocks.warfare = true
+  angelsmods.industries.blocks.enhancement5 = true
+  angelsmods.industries.blocks.energy5 = true
 end
 
 angelsmods.industries.overhaul = settings.startup["angels-enable-industries"].value -- enable industries

--- a/angelsindustries/prototypes/overrides/components-block-update.lua
+++ b/angelsindustries/prototypes/overrides/components-block-update.lua
@@ -315,66 +315,180 @@ if angelsmods.industries.components then
     -----------------------------------------------------------------------------
     -- ADVANCED BLOCKS 2 --------------------------------------------------------
     -----------------------------------------------------------------------------
-    if angelsmods.industries.tech then --these component blocks only show up in tech mode -at this point
-      data:extend(
+    data:extend(
+      {
         {
-          {
-            type = "technology",
-            name = "angels-advanced-blocks-2",
-            icon = "__angelsindustries__/graphics/technology/components-tech.png",
-            icon_size = 64,
-            prerequisites = {
-              "angels-advanced-blocks-1",
-              "utility-science-pack",
-              "tech-yellow-circuit",
-              "angels-components-mechanical-5",
-              "angels-components-cabling-5"
+          type = "technology",
+          name = "angels-advanced-blocks-2",
+          icon = "__angelsindustries__/graphics/technology/components-tech.png",
+          icon_size = 64,
+          prerequisites = {
+            "angels-advanced-blocks-1",
+            "utility-science-pack",
+            "tech-yellow-circuit",
+            "angels-components-mechanical-5",
+            "angels-components-cabling-5"
+          },
+          effects = {
+            {
+              type = "unlock-recipe",
+              recipe = "block-enhancement-5"
             },
-            effects = {
-              {
-                type = "unlock-recipe",
-                recipe = "block-enhancement-5"
-              },
-              {
-                type = "unlock-recipe",
-                recipe = "block-energy-5"
-              },
-              {
-                type = "unlock-recipe",
-                recipe = "block-exploration-5"
-              },
-              {
-                type = "unlock-recipe",
-                recipe = "block-logistic-5"
-              },
-              {
-                type = "unlock-recipe",
-                recipe = "block-production-5"
-              },
-              {
-                type = "unlock-recipe",
-                recipe = "block-warfare-5"
-              }
+            {
+              type = "unlock-recipe",
+              recipe = "block-energy-5"
             },
-            unit = {
-              count = 64,
-              ingredients = {
-                {type = "item", name = "automation-science-pack", amount = 1},
-                {type = "item", name = "logistic-science-pack", amount = 1},
-                {type = "item", name = "chemical-science-pack", amount = 1},
-                {type = "item", name = "utility-science-pack", amount = 1}
-              },
-              time = 60
+            {
+              type = "unlock-recipe",
+              recipe = "block-exploration-5"
             },
-            order = "a-5"
-          }
+            {
+              type = "unlock-recipe",
+              recipe = "block-logistic-5"
+            },
+            {
+              type = "unlock-recipe",
+              recipe = "block-production-5"
+            },
+            {
+              type = "unlock-recipe",
+              recipe = "block-warfare-5"
+            }
+          },
+          unit = {
+            count = 64,
+            ingredients = {
+              {type = "item", name = "automation-science-pack", amount = 1},
+              {type = "item", name = "logistic-science-pack", amount = 1},
+              {type = "item", name = "chemical-science-pack", amount = 1},
+              {type = "item", name = "utility-science-pack", amount = 1}
+            },
+            time = 60
+          },
+          order = "a-5"
         }
-      )
-    end
+      }
+    )
     OV.add_prereq("advanced-ore-refining-4", "angels-advanced-blocks-2")
     OV.set_science_pack("advanced-ore-refining-4", "utility-science-pack", 1)
     OV.add_prereq("angels-advanced-chemistry-4", "angels-advanced-blocks-2")
     OV.add_prereq("angels-metallurgy-5", "angels-advanced-blocks-2")
+
+    -- Disable unused blocks
+
+    if angelsmods.industries.blocks.exploration == false then
+      OV.disable_recipe(
+        {
+          "block-exploration-1",
+          "block-exploration-2",
+          "block-exploration-3",
+          "block-exploration-4",
+          "block-exploration-5"
+        }
+      )
+      angelsmods.functions.add_flag(
+        {
+          "block-exploration-1",
+          "block-exploration-2",
+          "block-exploration-3",
+          "block-exploration-4",
+          "block-exploration-5"
+        },
+        "hidden"
+      )
+    end
+    if angelsmods.industries.blocks.logistic == false then
+      OV.disable_recipe(
+        {
+          "block-logistic-1",
+          "block-logistic-2",
+          "block-logistic-3",
+          "block-logistic-4",
+          "block-logistic-5"
+        }
+      )
+      angelsmods.functions.add_flag(
+        {
+          "block-logistic-1",
+          "block-logistic-2",
+          "block-logistic-3",
+          "block-logistic-4",
+          "block-logistic-5"
+        },
+        "hidden"
+      )
+    end
+    if angelsmods.industries.blocks.warfare == false then
+      OV.disable_recipe(
+        {
+          "block-warfare-1",
+          "weapon-1",
+          "body-1",
+          "weapon-parts-trigger",
+          "angels-trigger",
+          "block-warfare-2",
+          "weapon-2",
+          "body-2",
+          "weapon-parts-explosionchamber",
+          "angels-explosionchamber",
+          "block-warfare-3",
+          "weapon-3",
+          "body-3",
+          "weapon-parts-fluidchamber",
+          "angels-fluidchamber",
+          "block-warfare-4",
+          "weapon-4",
+          "body-4",
+          "weapon-parts-energycrystal",
+          "angels-energycrystal",
+          "block-warfare-5",
+          "weapon-5",
+          "body-5",
+          "weapon-parts-acceleratorcoil",
+          "angels-acceleratorcoil"
+        }
+      )
+      angelsmods.functions.add_flag(
+        {
+          "block-warfare-1",
+          "weapon-1",
+          "body-1",
+          "weapon-parts",
+          "angels-trigger",
+          "block-warfare-2",
+          "weapon-2",
+          "body-2",
+          "angels-explosionchamber",
+          "block-warfare-3",
+          "weapon-3",
+          "body-3",
+          "angels-fluidchamber",
+          "block-warfare-4",
+          "weapon-4",
+          "body-4",
+          "angels-energycrystal",
+          "block-warfare-5",
+          "weapon-5",
+          "body-5",
+          "angels-acceleratorcoil"
+        },
+        "hidden"
+      )
+    end
+    if angelsmods.industries.blocks.enhancement5 == false then
+      OV.disable_recipe("block-enhancement-5")
+      angelsmods.functions.add_flag("block-enhancement-5", "hidden")
+    end
+    if angelsmods.industries.blocks.energy5 == false then
+      OV.disable_recipe("block-energy-5")
+      angelsmods.functions.add_flag("block-energy-5", "hidden")
+    end
+    if (angelsmods.industries.blocks.enhancement5 == false) and
+       (angelsmods.industries.blocks.exploration == false) and
+       (angelsmods.industries.blocks.logistic == false) then
+      OV.disable_recipe("angels-servo-motor-5")
+      angelsmods.functions.add_flag("angels-servo-motor-5", "hidden")
+    end
 
     if mods["bobmodules"] then
     else

--- a/angelsindustries/prototypes/overrides/components-bobs-entity-update/components-bobs-assemblers-update.lua
+++ b/angelsindustries/prototypes/overrides/components-bobs-entity-update/components-bobs-assemblers-update.lua
@@ -67,6 +67,8 @@ if angelsmods.industries.components then
       }
     )
 
+    angelsmods.industries.blocks.enhancement5 = true
+
     OV.remove_prereq("automation-2", "angels-components-construction-2")
     OV.remove_prereq("automation-3", "advanced-electronics")
     OV.remove_prereq("automation-5", "advanced-electronics-2")

--- a/angelsindustries/prototypes/overrides/components-bobs-entity-update/components-bobs-power-update.lua
+++ b/angelsindustries/prototypes/overrides/components-bobs-entity-update/components-bobs-power-update.lua
@@ -112,6 +112,8 @@ if angelsmods.industries.components then
         }
       )
 
+      angelsmods.industries.blocks.energy5 = true
+
       if angelsmods.industries.tech then
         OV.add_prereq("bob-solar-energy-2", "tech-specialised-labs-basic-energy-3")
         OV.add_prereq("bob-solar-energy-3", "tech-specialised-labs-advanced-energy-1")
@@ -221,6 +223,9 @@ if angelsmods.industries.components then
           }
         }
       )
+
+      angelsmods.industries.blocks.enhancement5 = true
+      angelsmods.industries.blocks.energy5 = true
 
       OV.remove_prereq("bob-electric-energy-accumulators-3", "advanced-electronics")
       OV.remove_prereq("bob-electric-energy-accumulators-4", "advanced-electronics-2")


### PR DESCRIPTION
### Fix missing technology error
- Components overhaul enabled
- Technology overhaul disabled

![image](https://user-images.githubusercontent.com/59639/180730458-35717138-600a-41d8-abf3-876f27456c43.png)

Error exists even without any of Bob's mods

### Hide unused blocks
- Logistic block 1 - 5
- Exploration block 1 - 5
- Warfare block 1 - 5
- Warfare block ingredients (weapon, body, weapon parts etc)
- Enhancement block 5 (if not used for Bob's)
- Energy block 5 (if not used for Bob's)


