### PR TITLE
Fix accidental globals and references to undeclared variables

### DIFF
--- a/angelsaddons-mobility/data.lua
+++ b/angelsaddons-mobility/data.lua
@@ -20,8 +20,6 @@ angelsmods.addons.mobility.smeltingtrain.number_tint = {r = 1, g = 0.38, b = 0, 
 
 
 
-tech_unlocks = {}
-
 require("prototypes.categories")
 --CRAWLER
 require("prototypes.entities.crawler-locomotive")
@@ -45,5 +43,3 @@ require("prototypes.technology.crawler-technology")
 require("prototypes.technology.petro-technology")
 --SMELTING
 require("prototypes.technology.smelting-technology")
-
-tech_unlocks = nil

--- a/angelsaddons-mobility/prototypes/train-functions.lua
+++ b/angelsaddons-mobility/prototypes/train-functions.lua
@@ -1,5 +1,7 @@
 require("util")
 
+local tech_unlocks = {}
+
 local function set_type(name)
   local train_type
   if string.find(name,"crawler") then
@@ -34,7 +36,7 @@ local function add_speed_locale()
 end
 
 local function generate_additional_pastable_entities(name)
-  all_entity_names = {}
+  local all_entity_names = {}
   for _, entity_type_name in pairs{
     "crawler-locomotive",
     "crawler-locomotive-wagon",

--- a/angelsexploration/prototypes/entities/biter-builder.lua
+++ b/angelsexploration/prototypes/entities/biter-builder.lua
@@ -14,6 +14,8 @@ local function new_random_seed()
   return enemy_random_seed
 end
 
+local control_name = "enemy-base"
+
 -- Copy from base.. since local...
 local function enemy_autoplace(params)
   local distance_factor = params.distance_factor or 1
@@ -825,7 +827,7 @@ local function make_attack_parameter(data_app, data_dmg)
     damage_modifier = data_dmg.damage_modifier,
     warmup = data_dmg.warmup,
     ammo_type = data_dmg.ammo,
-    sound = make_roar_sound(data_app.type, volume),
+    sound = make_roar_sound(data_app.type, nil), -- TODO: replace nil with atual volume
     animation = make_attack_animation(data_app)
   }
 end
@@ -1048,11 +1050,11 @@ function angelsmods.functions.update_spawner(us_data)
     --log(serpent.block(spawner))
     spawner.resistances = spawner.resistances or {}
     for _,new_resistance_data in pairs(us_data.resistance or {}) do
-      local existing_resistace = false
+      local existing_resistance = false
       for old_resistance_index,old_resistance_data in pairs(spawner.resistances) do
         if old_resistance_data.type == new_resistance_data.type then
           spawner.resistances[old_resistance_index] = new_resistance_data
-          existing_resistace = true
+          existing_resistance = true
           break
         end
       end
@@ -1072,7 +1074,7 @@ function angelsmods.functions.update_spawner(us_data)
           break
         end
       end
-      if not existing_resistance then
+      if not existing_result_unit then
         table.insert(spawner.result_units, new_result_unit_data)
       end
     end

--- a/angelsexploration/prototypes/entities/biter-definitions.lua
+++ b/angelsexploration/prototypes/entities/biter-definitions.lua
@@ -1,3 +1,5 @@
+local biter_definitions = {}
+
 --HEALTH:
 --SCARAB: 150/300/450/600/750
 --BITER 100/200/300/400/500
@@ -23,7 +25,7 @@
 -------------------------------------------------------------------------------
 -- BITER DEFINITIONS ----------------------------------------------------------
 -------------------------------------------------------------------------------
-small_biter =
+biter_definitions.small_biter =
 {
   appearance = {
     type = "biter",
@@ -59,7 +61,7 @@ small_biter =
   --}
 }
 
-medium_biter =
+biter_definitions.medium_biter =
 {
   appearance = {
     type = "biter",
@@ -92,7 +94,7 @@ medium_biter =
   }
 }
 
-big_biter =
+biter_definitions.big_biter =
 {
   appearance = {
     type = "biter",
@@ -125,7 +127,7 @@ big_biter =
   }
 }
 
-behemoth_biter =
+biter_definitions.behemoth_biter =
 {
   appearance = {
     type = "biter",
@@ -158,7 +160,7 @@ behemoth_biter =
   }
 }
 
-colossal_biter =
+biter_definitions.colossal_biter =
 {
   appearance = {
     type = "biter",
@@ -196,7 +198,7 @@ colossal_biter =
 -------------------------------------------------------------------------------
 -- SPITTER DEFINITIONS --------------------------------------------------------
 -------------------------------------------------------------------------------
-small_spitter =
+biter_definitions.small_spitter =
 {
   appearance = {
     type = "spitter",
@@ -227,7 +229,7 @@ small_spitter =
   }
 }
 
-medium_spitter =
+biter_definitions.medium_spitter =
 {
   appearance = {
     type = "spitter",
@@ -258,7 +260,7 @@ medium_spitter =
   }
 }
 
-big_spitter =
+biter_definitions.big_spitter =
 {
   appearance = {
     type = "spitter",
@@ -289,7 +291,7 @@ big_spitter =
   }
 }
 
-behemoth_spitter =
+biter_definitions.behemoth_spitter =
 {
   appearance = {
     type = "spitter",
@@ -320,7 +322,7 @@ behemoth_spitter =
   }
 }
 
-colossal_spitter =
+biter_definitions.colossal_spitter =
 {
   appearance = {
     type = "spitter",
@@ -356,7 +358,7 @@ colossal_spitter =
 -------------------------------------------------------------------------------
 -- SCARAB DEFINITIONS ---------------------------------------------------------
 -------------------------------------------------------------------------------
-small_scarab =
+biter_definitions.small_scarab =
 {
   appearance = {
     type = "scarab",
@@ -387,7 +389,7 @@ small_scarab =
   }
 }
 
-medium_scarab =
+biter_definitions.medium_scarab =
 {
   appearance = {
     type = "scarab",
@@ -418,7 +420,7 @@ medium_scarab =
   }
 }
 
-big_scarab =
+biter_definitions.big_scarab =
 {
   appearance = {
     type = "scarab",
@@ -449,7 +451,7 @@ big_scarab =
   }
 }
 
-behemoth_scarab =
+biter_definitions.behemoth_scarab =
 {
   appearance = {
     type = "scarab",
@@ -480,7 +482,7 @@ behemoth_scarab =
   }
 }
 
-colossal_scarab =
+biter_definitions.colossal_scarab =
 {
   appearance = {
     type = "scarab",
@@ -514,7 +516,7 @@ colossal_scarab =
 -------------------------------------------------------------------------------
 -- PSYKER DEFINITIONS ---------------------------------------------------------
 -------------------------------------------------------------------------------
-small_psyker =
+biter_definitions.small_psyker =
 {
   appearance = {
     type = "psyker",
@@ -545,7 +547,7 @@ small_psyker =
   }
 }
 
-medium_psyker =
+biter_definitions.medium_psyker =
 {
   appearance = {
     type = "psyker",
@@ -576,7 +578,7 @@ medium_psyker =
   }
 }
 
-big_psyker =
+biter_definitions.big_psyker =
 {
   appearance = {
     type = "psyker",
@@ -607,7 +609,7 @@ big_psyker =
   }
 }
 
-behemoth_psyker =
+biter_definitions.behemoth_psyker =
 {
   appearance = {
     type = "psyker",
@@ -638,7 +640,7 @@ behemoth_psyker =
   }
 }
 
-colossal_psyker =
+biter_definitions.colossal_psyker =
 {
   appearance = {
     type = "psyker",
@@ -672,7 +674,7 @@ colossal_psyker =
 -------------------------------------------------------------------------------
 -- SPAWNER DEFINITIONS --------------------------------------------------------
 -------------------------------------------------------------------------------
-biter_spawner =
+biter_definitions.biter_spawner =
 {
   appearance = {
     type = "biter",
@@ -693,7 +695,7 @@ biter_spawner =
   }
 }
 
-spitter_spawner =
+biter_definitions.spitter_spawner =
 {
   appearance = {
     type = "spitter",
@@ -714,7 +716,7 @@ spitter_spawner =
   }
 }
 
-scarab_spawner =
+biter_definitions.scarab_spawner =
 {
   appearance = {
     type = "scarab",
@@ -740,7 +742,7 @@ scarab_spawner =
   }
 }
 
-psyker_spawner =
+biter_definitions.psyker_spawner =
 {
   appearance = {
     type = "psyker",
@@ -766,3 +768,5 @@ psyker_spawner =
     {type = "plasma", decrease = 5, percent = 10}
   }
 }
+
+return biter_definitions

--- a/angelsexploration/prototypes/entities/biter.lua
+++ b/angelsexploration/prototypes/entities/biter.lua
@@ -1,22 +1,22 @@
 -- INCLUDE BUILDER PROPERTIES
-require("prototypes.entities.biter-definitions")
+local biter_definitions = require("prototypes.entities.biter-definitions")
 
 -- EXECUTE
-angelsmods.functions.make_alien(colossal_biter)
+angelsmods.functions.make_alien(biter_definitions.colossal_biter)
 
-angelsmods.functions.make_alien(colossal_spitter)
+angelsmods.functions.make_alien(biter_definitions.colossal_spitter)
 
-angelsmods.functions.make_alien(small_scarab)
-angelsmods.functions.make_alien(medium_scarab)
-angelsmods.functions.make_alien(big_scarab)
-angelsmods.functions.make_alien(behemoth_scarab)
-angelsmods.functions.make_alien(colossal_scarab)
+angelsmods.functions.make_alien(biter_definitions.small_scarab)
+angelsmods.functions.make_alien(biter_definitions.medium_scarab)
+angelsmods.functions.make_alien(biter_definitions.big_scarab)
+angelsmods.functions.make_alien(biter_definitions.behemoth_scarab)
+angelsmods.functions.make_alien(biter_definitions.colossal_scarab)
 
-angelsmods.functions.make_alien(small_psyker)
-angelsmods.functions.make_alien(medium_psyker)
-angelsmods.functions.make_alien(big_psyker)
-angelsmods.functions.make_alien(behemoth_psyker)
-angelsmods.functions.make_alien(colossal_psyker)
+angelsmods.functions.make_alien(biter_definitions.small_psyker)
+angelsmods.functions.make_alien(biter_definitions.medium_psyker)
+angelsmods.functions.make_alien(biter_definitions.big_psyker)
+angelsmods.functions.make_alien(biter_definitions.behemoth_psyker)
+angelsmods.functions.make_alien(biter_definitions.colossal_psyker)
 
-angelsmods.functions.make_alien_spawner(scarab_spawner)
-angelsmods.functions.make_alien_spawner(psyker_spawner)
+angelsmods.functions.make_alien_spawner(biter_definitions.scarab_spawner)
+angelsmods.functions.make_alien_spawner(biter_definitions.psyker_spawner)

--- a/angelsexploration/prototypes/entities/gathering-turret-builder.lua
+++ b/angelsexploration/prototypes/entities/gathering-turret-builder.lua
@@ -526,7 +526,6 @@ function angelsmods.functions.create_gathering_turret_beam_body(inputs)
       width = 32,
       height = 39,
       frame_count = 16,
-      tint = beam_tint,
       blend_mode = inputs.blend_mode
     },
     {

--- a/angelsexploration/prototypes/entities/vehicles.lua
+++ b/angelsexploration/prototypes/entities/vehicles.lua
@@ -47,12 +47,25 @@ data:extend(
         projectile_center = {-0.15625, -0.07812},
         projectile_creation_distance = 1,
         range = 20,
-        sound = heavy_gunshot --[[{
+        sound =
           {
-            filename="__base__/prototypes/entity/sounds/heavy_gunshot.ogg",--make_heavy_gunshot_sounds()
-            volume=1.0,
-          }
-        },]]
+            {
+              filename = "__base__/sound/fight/heavy-gunshot-1.ogg",
+              volume = 0.4
+            },
+            {
+              filename = "__base__/sound/fight/heavy-gunshot-2.ogg",
+              volume = 0.4
+            },
+            {
+              filename = "__base__/sound/fight/heavy-gunshot-3.ogg",
+              volume = 0.4
+            },
+            {
+              filename = "__base__/sound/fight/heavy-gunshot-4.ogg",
+              volume = 0.4
+            }
+          },
       },
       stack_size = 1
     },

--- a/angelsexploration/prototypes/overrides/biter-updates.lua
+++ b/angelsexploration/prototypes/overrides/biter-updates.lua
@@ -52,21 +52,21 @@ end
 --end
 
 --ADD RESISTANCES
-require("prototypes.entities.biter-definitions") -- does not hurt to re-include it to make sure the variables are up to date
-angelsmods.functions.update_alien(small_biter)
-angelsmods.functions.update_alien(medium_biter)
-angelsmods.functions.update_alien(big_biter)
-angelsmods.functions.update_alien(behemoth_biter)
-angelsmods.functions.update_alien(colossal_biter)
+local biter_definitions = require("prototypes.entities.biter-definitions")
+angelsmods.functions.update_alien(biter_definitions.small_biter)
+angelsmods.functions.update_alien(biter_definitions.medium_biter)
+angelsmods.functions.update_alien(biter_definitions.big_biter)
+angelsmods.functions.update_alien(biter_definitions.behemoth_biter)
+angelsmods.functions.update_alien(biter_definitions.colossal_biter)
 
-angelsmods.functions.update_alien(small_spitter)
-angelsmods.functions.update_alien(medium_spitter)
-angelsmods.functions.update_alien(big_spitter)
-angelsmods.functions.update_alien(behemoth_spitter)
-angelsmods.functions.update_alien(colossal_spitter)
+angelsmods.functions.update_alien(biter_definitions.small_spitter)
+angelsmods.functions.update_alien(biter_definitions.medium_spitter)
+angelsmods.functions.update_alien(biter_definitions.big_spitter)
+angelsmods.functions.update_alien(biter_definitions.behemoth_spitter)
+angelsmods.functions.update_alien(biter_definitions.colossal_spitter)
 
-angelsmods.functions.update_spawner(spitter_spawner)
-angelsmods.functions.update_spawner(biter_spawner)
+angelsmods.functions.update_spawner(biter_definitions.spitter_spawner)
+angelsmods.functions.update_spawner(biter_definitions.biter_spawner)
 
 --SHOW RESISTANCES
 for _, unit in pairs(data.raw.unit) do

--- a/angelsindustries/prototypes/overrides/industries-override-functions.lua
+++ b/angelsindustries/prototypes/overrides/industries-override-functions.lua
@@ -282,7 +282,7 @@ function angelsmods.functions.AI.core_tier_upgrade()
     -- now update the core if required and also depend on the correct tech
     if pack_name then
       if core_name then
-        core_type = string.sub(core_name, 9, -2)
+        local core_type = string.sub(core_name, 9, -2)
         if string.sub(core_type, 1, 1) == "-" and string.sub(core_type, -1, -1) == "-" then
           local research_type = string.sub(core_type, 2, -2)
 
@@ -366,10 +366,10 @@ function angelsmods.functions.AI.replace_blocks_list(ing_list) --specifically bu
   end
   --now do the replacements -- id rather not have to do a double loop
   for n, _ in pairs(ing_list) do
-    nme = ing_list[n].name
+    local nme = ing_list[n].name
     if block_replace[nme] then
-      new = block_replace[nme].new
-      amt_multi = block_replace[nme].amt_multi
+      local new = block_replace[nme].new
+      local amt_multi = block_replace[nme].amt_multi
       if existing[new] then
         --if it exists, just add more? may just remove this
         if ing_list[n].amount and ing_list[n].amount ~= existing[new][amount] then
@@ -421,17 +421,17 @@ function angelsmods.functions.AI.replace_con_mats(buildings)
       local rec_check = data.raw.recipe[assembly_check]
       if rec_check.normal or rec_check.expensive then
         if rec_check.normal then
-          ing_list = rec_check.normal.ingredients
+          local ing_list = rec_check.normal.ingredients
           angelsmods.functions.AI.replace_blocks_list(ing_list)
           rec_check.normal.energy_required = 0.5
         end
         if rec_check.expensive then
-          ing_list = rec_check.expensive.ingredients
+          local ing_list = rec_check.expensive.ingredients
           angelsmods.functions.AI.replace_blocks_list(ing_list)
           rec_check.expensive.energy_required = 0.5
         end
       else
-        ing_list = rec_check.ingredients
+        local ing_list = rec_check.ingredients
         angelsmods.functions.AI.replace_blocks_list(ing_list)
         rec_check.energy_required = 0.5
       end

--- a/angelsindustries/prototypes/recipes/components-mechanical-recipes.lua
+++ b/angelsindustries/prototypes/recipes/components-mechanical-recipes.lua
@@ -34,6 +34,9 @@ if angelsmods.industries.components then
     }
   )
   for _, metal in pairs({"iron", "steel", "aluminium", "titanium" --[[,"tungsten"]]}) do --all of the metals in one go
+    local num
+    local molten1
+    local molten2
     if metal == "iron" then
       num = 1
       molten1 = {type = "fluid", name = "liquid-molten-iron", amount = 15}

--- a/angelspetrochem/prototypes/buildings/air-filter.lua
+++ b/angelspetrochem/prototypes/buildings/air-filter.lua
@@ -72,7 +72,7 @@ data:extend(
     {
       {
         production_type = "input",
-        pipe_picture = electrolyserpictures(),
+        pipe_picture = angelsmods.petrochem.electrolyserpictures(),
         pipe_covers = pipecoverspictures(),
         base_area = 10,
         base_level = -1,
@@ -80,7 +80,7 @@ data:extend(
       },
       {
         production_type = "output",
-        pipe_picture = electrolyserpictures(),
+        pipe_picture = angelsmods.petrochem.electrolyserpictures(),
         pipe_covers = pipecoverspictures(),
         base_level = 1,
         pipe_connections = {{ position = {0, 3} }}
@@ -158,7 +158,7 @@ data:extend(
     {
       {
         production_type = "input",
-        pipe_picture = electrolyserpictures(),
+        pipe_picture = angelsmods.petrochem.electrolyserpictures(),
         pipe_covers = pipecoverspictures(),
         base_area = 10,
         base_level = -1,
@@ -166,7 +166,7 @@ data:extend(
       },
       {
         production_type = "output",
-        pipe_picture = electrolyserpictures(),
+        pipe_picture = angelsmods.petrochem.electrolyserpictures(),
         pipe_covers = pipecoverspictures(),
         base_level = 1,
         pipe_connections = {{ position = {0, 3} }}

--- a/angelspetrochem/prototypes/buildings/electrolyser.lua
+++ b/angelspetrochem/prototypes/buildings/electrolyser.lua
@@ -96,7 +96,7 @@ data:extend(
       fluid_boxes = {
         {
           production_type = "input",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -104,7 +104,7 @@ data:extend(
         },
         {
           production_type = "input",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -112,14 +112,14 @@ data:extend(
         },
         {
           production_type = "output",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {-2, 3}}}
         },
         {
           production_type = "output",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {2, 3}}}
@@ -222,7 +222,7 @@ data:extend(
       fluid_boxes = {
         {
           production_type = "input",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -230,7 +230,7 @@ data:extend(
         },
         {
           production_type = "input",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -238,14 +238,14 @@ data:extend(
         },
         {
           production_type = "output",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {-2, 3}}}
         },
         {
           production_type = "output",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {2, 3}}}
@@ -348,7 +348,7 @@ data:extend(
       fluid_boxes = {
         {
           production_type = "input",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -356,7 +356,7 @@ data:extend(
         },
         {
           production_type = "input",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -364,14 +364,14 @@ data:extend(
         },
         {
           production_type = "output",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {-2, 3}}}
         },
         {
           production_type = "output",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {2, 3}}}
@@ -473,7 +473,7 @@ data:extend(
       fluid_boxes = {
         {
           production_type = "input",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -481,7 +481,7 @@ data:extend(
         },
         {
           production_type = "input",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -489,14 +489,14 @@ data:extend(
         },
         {
           production_type = "output",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {-2, 3}}}
         },
         {
           production_type = "output",
-          pipe_picture = electrolyserpictures(),
+          pipe_picture = angelsmods.petrochem.electrolyserpictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {2, 3}}}

--- a/angelspetrochem/prototypes/buildings/pipes-overlay.lua
+++ b/angelspetrochem/prototypes/buildings/pipes-overlay.lua
@@ -1,4 +1,4 @@
-function electrolyserpictures()
+function angelsmods.petrochem.electrolyserpictures()
   return
   {
     north =
@@ -36,7 +36,7 @@ function electrolyserpictures()
   }
 end
 
-function coverpictures()
+local function coverpictures()
   return
   {
     north =
@@ -75,7 +75,7 @@ function coverpictures()
   }
 end
 
-function polypictures1()
+local function polypictures1()
   return
   {
 	north =
@@ -117,7 +117,7 @@ function polypictures1()
   }
 end
 
-function polypictures2()
+local function polypictures2()
   return
   {
 	north =
@@ -159,7 +159,7 @@ function polypictures2()
   }
 end
 
-function polypictures3()
+local function polypictures3()
   return
   {
 	north =

--- a/angelsrefining/prototypes/angels-functions.lua
+++ b/angelsrefining/prototypes/angels-functions.lua
@@ -299,8 +299,8 @@ local function create_recipe_molecule_icons(molecules_icon, molecules_shift, mol
     molecule_icon = molecules_icon[molecule_index]
 
     -- now shift this icon to its correct position
-    molecule_shift = molecules_shift[molecule_index] or {0, 0}
-    molecule_scale = molecules_scale
+    local molecule_shift = molecules_shift[molecule_index] or {0, 0}
+    local molecule_scale = molecules_scale
     for layer_index, layer in pairs(molecule_icon) do
       layer.scale = layer.scale or 1
       layer.shift = {(layer.shift or {})[1] or 0, (layer.shift or {})[2] or 0}
@@ -1246,8 +1246,8 @@ function angelsmods.functions.fluid_color(chemical_formula) --color blending bas
 end
 
 function angelsmods.functions.flow_color(chemical_formula) --makes it lighter by some margin
-  change = total_shade(chemical_formula)*6
-  chemical_formula = chemical_formula.."H"..change--table.insert(chemical_formula,"H"..change)
+  local change = total_shade(chemical_formula)*6
+  local chemical_formula = chemical_formula.."H"..change--table.insert(chemical_formula,"H"..change)
   local color = angelsmods.functions.fluid_color(chemical_formula)
   return color
 end
@@ -1453,7 +1453,7 @@ function angelsmods.functions.remove_flag(entity, flag_to_remove) -- Removes a f
   end
   --actual entity if not not just an item
   for _,type in pairs(building_types) do
-    to_remove = data.raw[type][entity] --entity-types...
+    local to_remove = data.raw[type][entity] --entity-types...
     if to_remove then
       for flag_index, flag in pairs(to_remove.flags or {}) do
         if flag == flag_to_remove then
@@ -1596,7 +1596,15 @@ end
 function angelsmods.functions.make_void(fluid_name, void_category, void_amount) -- categories: chemical (fluid, flare-stack)
   --LOCAL DEFINITIONS                                                           --             water (fluild, clarifier)
   local recipe = {}                                                             --             bio (item, compost)
-                                                                                -- amount(optional): amount of input/output, default 1
+  local void_input_amount                                                       -- amount(optional): amount of input/output, default 1
+  local void_input_type
+  local void_input_subgroup
+  local void_process_time
+  local void_output_item
+  local void_output_amount
+  local void_output_probability
+  local void_tint
+
   if data.raw.fluid[fluid_name] then -- fluid voids
     if void_category == "water" then
       void_amount = void_amount or 400

--- a/angelsrefining/prototypes/buildings/electro-whinning-cell.lua
+++ b/angelsrefining/prototypes/buildings/electro-whinning-cell.lua
@@ -80,7 +80,7 @@ data:extend(
       fluid_boxes = {
         {
           production_type = "input",
-          pipe_picture = floatationpipepictures(),
+          pipe_picture = angelsmods.refining.floatationpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -88,7 +88,7 @@ data:extend(
         },
         {
           production_type = "input",
-          pipe_picture = floatationpipepictures(),
+          pipe_picture = angelsmods.refining.floatationpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -96,14 +96,14 @@ data:extend(
         },
         {
           production_type = "output",
-          pipe_picture = floatationpipepictures(),
+          pipe_picture = angelsmods.refining.floatationpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {1, -3}}}
         },
         {
           production_type = "output",
-          pipe_picture = floatationpipepictures(),
+          pipe_picture = angelsmods.refining.floatationpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {-1, -3}}}
@@ -190,7 +190,7 @@ data:extend(
       fluid_boxes = {
         {
           production_type = "input",
-          pipe_picture = floatationpipepictures(),
+          pipe_picture = angelsmods.refining.floatationpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -198,7 +198,7 @@ data:extend(
         },
         {
           production_type = "input",
-          pipe_picture = floatationpipepictures(),
+          pipe_picture = angelsmods.refining.floatationpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -206,14 +206,14 @@ data:extend(
         },
         {
           production_type = "output",
-          pipe_picture = floatationpipepictures(),
+          pipe_picture = angelsmods.refining.floatationpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {1, -3}}}
         },
         {
           production_type = "output",
-          pipe_picture = floatationpipepictures(),
+          pipe_picture = angelsmods.refining.floatationpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {-1, -3}}}
@@ -299,7 +299,7 @@ data:extend(
       fluid_boxes = {
         {
           production_type = "input",
-          pipe_picture = floatationpipepictures(),
+          pipe_picture = angelsmods.refining.floatationpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -307,7 +307,7 @@ data:extend(
         },
         {
           production_type = "input",
-          pipe_picture = floatationpipepictures(),
+          pipe_picture = angelsmods.refining.floatationpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -315,14 +315,14 @@ data:extend(
         },
         {
           production_type = "output",
-          pipe_picture = floatationpipepictures(),
+          pipe_picture = angelsmods.refining.floatationpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {1, -3}}}
         },
         {
           production_type = "output",
-          pipe_picture = floatationpipepictures(),
+          pipe_picture = angelsmods.refining.floatationpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {-1, -3}}}

--- a/angelsrefining/prototypes/buildings/filtration-unit.lua
+++ b/angelsrefining/prototypes/buildings/filtration-unit.lua
@@ -78,7 +78,7 @@ data:extend(
         {
           production_type = "input",
           pipe_covers = pipecoverspictures(),
-          pipe_picture = filtrationpipepictures(),
+          pipe_picture = angelsmods.refining.filtrationpipepictures(),
           base_area = 10,
           base_level = -1,
           pipe_connections = {{type = "input", position = {1, 3}}}
@@ -86,7 +86,7 @@ data:extend(
         {
           production_type = "input",
           pipe_covers = pipecoverspictures(),
-          pipe_picture = filtrationpipepictures(),
+          pipe_picture = angelsmods.refining.filtrationpipepictures(),
           base_area = 10,
           base_level = -1,
           pipe_connections = {{type = "input", position = {-1, 3}}}
@@ -94,14 +94,14 @@ data:extend(
         {
           production_type = "output",
           pipe_covers = pipecoverspictures(),
-          pipe_picture = filtrationpipepictures(),
+          pipe_picture = angelsmods.refining.filtrationpipepictures(),
           base_level = 1,
           pipe_connections = {{position = {1, -3}}}
         },
         {
           production_type = "output",
           pipe_covers = pipecoverspictures(),
-          pipe_picture = filtrationpipepictures(),
+          pipe_picture = angelsmods.refining.filtrationpipepictures(),
           base_level = 1,
           pipe_connections = {{position = {-1, -3}}}
         }
@@ -184,7 +184,7 @@ data:extend(
         {
           production_type = "input",
           pipe_covers = pipecoverspictures(),
-          pipe_picture = filtrationpipepictures(),
+          pipe_picture = angelsmods.refining.filtrationpipepictures(),
           base_area = 10,
           base_level = -1,
           pipe_connections = {{type = "input", position = {1, 3}}}
@@ -192,7 +192,7 @@ data:extend(
         {
           production_type = "input",
           pipe_covers = pipecoverspictures(),
-          pipe_picture = filtrationpipepictures(),
+          pipe_picture = angelsmods.refining.filtrationpipepictures(),
           base_area = 10,
           base_level = -1,
           pipe_connections = {{type = "input", position = {-1, 3}}}
@@ -200,14 +200,14 @@ data:extend(
         {
           production_type = "output",
           pipe_covers = pipecoverspictures(),
-          pipe_picture = filtrationpipepictures(),
+          pipe_picture = angelsmods.refining.filtrationpipepictures(),
           base_level = 1,
           pipe_connections = {{position = {1, -3}}}
         },
         {
           production_type = "output",
           pipe_covers = pipecoverspictures(),
-          pipe_picture = filtrationpipepictures(),
+          pipe_picture = angelsmods.refining.filtrationpipepictures(),
           base_level = 1,
           pipe_connections = {{position = {-1, -3}}}
         }

--- a/angelsrefining/prototypes/buildings/ore-leaching-plant.lua
+++ b/angelsrefining/prototypes/buildings/ore-leaching-plant.lua
@@ -65,7 +65,7 @@ data:extend(
       fluid_boxes = {
         {
           production_type = "input",
-          pipe_picture = leachingpipepictures(),
+          pipe_picture = angelsmods.refining.leachingpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -73,7 +73,7 @@ data:extend(
         },
         {
           production_type = "output",
-          pipe_picture = leachingpipepictures(),
+          pipe_picture = angelsmods.refining.leachingpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {-1, -3}}}
@@ -159,7 +159,7 @@ data:extend(
       fluid_boxes = {
         {
           production_type = "input",
-          pipe_picture = leachingpipepictures(),
+          pipe_picture = angelsmods.refining.leachingpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -167,7 +167,7 @@ data:extend(
         },
         {
           production_type = "output",
-          pipe_picture = leachingpipepictures(),
+          pipe_picture = angelsmods.refining.leachingpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {-1, -3}}}
@@ -251,7 +251,7 @@ data:extend(
       fluid_boxes = {
         {
           production_type = "input",
-          pipe_picture = leachingpipepictures(),
+          pipe_picture = angelsmods.refining.leachingpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
@@ -259,7 +259,7 @@ data:extend(
         },
         {
           production_type = "output",
-          pipe_picture = leachingpipepictures(),
+          pipe_picture = angelsmods.refining.leachingpipepictures(),
           pipe_covers = pipecoverspictures(),
           base_level = 1,
           pipe_connections = {{position = {-1, -3}}}

--- a/angelsrefining/prototypes/buildings/pipes-overlay.lua
+++ b/angelsrefining/prototypes/buildings/pipes-overlay.lua
@@ -1,4 +1,4 @@
-function floatationpipepictures()
+function angelsmods.refining.floatationpipepictures()
   -- used by electrowinning still... not by floatation cell itself
   return {
     north = {
@@ -32,7 +32,7 @@ function floatationpipepictures()
   }
 end
 
-function leachingpipepictures()
+function angelsmods.refining.leachingpipepictures()
   return {
     north = {
       filename = "__angelsrefining__/graphics/entity/ore-leaching-plant/empty.png",
@@ -65,7 +65,7 @@ function leachingpipepictures()
   }
 end
 
-function filtrationpipepictures()
+function angelsmods.refining.filtrationpipepictures()
   return {
     north = {
       filename = "__angelsrefining__/graphics/entity/filtration-unit/pipe-north.png",

--- a/angelsrefining/prototypes/generation/angels-ore.lua
+++ b/angelsrefining/prototypes/generation/angels-ore.lua
@@ -48,6 +48,8 @@ angelsmods.functions.add_resource(
   }
 )
 
+local ore_3_icon
+local ore_3_icon_size
 if settings.startup["angels-tryptophobia-friendly-stiratite"].value == true then
   ore_3_icon = "__angelsrefining__/graphics/icons/angels-ore3.png"
   ore_3_icon_size = 32

--- a/angelsrefining/prototypes/generation/resource-builder.lua
+++ b/angelsrefining/prototypes/generation/resource-builder.lua
@@ -169,7 +169,7 @@ local function make_resgfx(input)
       input.variation_count = 8
     end
     if input.get then
-      stages_copy = table.deepcopy(data.raw.resource[input.get].stages)
+      local stages_copy = table.deepcopy(data.raw.resource[input.get].stages)
       --log(serpent.block(stages_copy))
       return stages_copy
     else
@@ -382,6 +382,7 @@ local function make_resgfx(input)
         }
       end
       if input.sheet == 9 then
+        local sheet_id
         if settings.startup["angels-tryptophobia-friendly-stiratite"].value == true then
           sheet_id = 11
         else
@@ -542,7 +543,7 @@ local function make_resglow(input)
   if input.glow == true then
     if input.type == "item" then
       if input.get and data.raw.resource[input.get] then
-        stages_input = data.raw.resource[input.get].stages
+        local stages_input = data.raw.resource[input.get].stages
         input.frame_count = stages_input.sheet.frame_count
         input.variation_count = stages_input.sheet.variation_count
       else
@@ -916,7 +917,7 @@ end
 --CREATE RESOURCE FROM STORE
 function angelsmods.functions.make_resource()
   for r, input in pairs(angelsmods.functions.store.make) do
-    ret_table = {
+    local ret_table = {
       type = "resource",
       flags = {"placeable-neutral"},
       tree_removal_probability = 0.8,
@@ -924,7 +925,7 @@ function angelsmods.functions.make_resource()
       infinite_depletion_amount = 10,
       resource_patch_search_radius = 12
     }
-    autoplace_ret_table = {
+    local autoplace_ret_table = {
       name = input.name,
       order = input.order,
       base_density = input.autoplace.base_density,
@@ -975,6 +976,7 @@ function angelsmods.functions.make_resource()
         input.hardness = 0.9
       end]]
       --Set stages count according to resource type
+      local stages_count
       if input.type == "item" then
         if input.infinite == true then
           stages_count = {1}

--- a/angelsrefining/prototypes/tips-and-tricks-functions.lua
+++ b/angelsrefining/prototypes/tips-and-tricks-functions.lua
@@ -1,4 +1,4 @@
-tnt = {} --init table
+local tnt = {} --init table
 
 tnt.get_item_from_name = function(item_name, item_type, before, ending)
   before = before or "- "

--- a/angelsrefining/prototypes/tips-and-tricks/1-3-water-processing/1-3-water-processing-description.lua
+++ b/angelsrefining/prototypes/tips-and-tricks/1-3-water-processing/1-3-water-processing-description.lua
@@ -14,8 +14,8 @@ else -- overhaul mode
     table.insert(items,tnt.get_item_from_name("solid-salt","item", "- gives: "))
     table.insert(items,tnt.get_item_from_name("water-greenyellow-waste","fluid","\n[font=default-bold]"))
     table.insert(items,tnt.get_item_from_name("fluorite-ore","item", "- gives: "))
+    table.insert(description, items)
   end
-  table.insert(description, items)
 end
 table.insert(description,{"tips-and-tricks-description.angels-water-processing-voiding"})
 return description


### PR DESCRIPTION
Found by temporarily adding the following code to angelsrefining/data.lua

```lua
setmetatable(_G, {
  __newindex = function (_, n)
    error("attempt to write to undeclared variable "..n)
  end,
  __index = function (_, n)
    error("attempt to read undeclared variable "..n)
  end,
})
```