### PR TITLE
Adding mod directory parameter to unit test runner

### DIFF
--- a/angelsdev-unit-test/python/factorio_controller.py
+++ b/angelsdev-unit-test/python/factorio_controller.py
@@ -7,7 +7,7 @@ import time
 
 class FactorioController:
 
-  def __init__(self, factorioInstallDir:Optional[str]=None, log:Optional[Callable[[str], None]]=None):
+  def __init__(self, factorioInstallDir:Optional[str]=None, log:Optional[Callable[[str], None]]=None, factorioModDir:Optional[str]=None):
     if factorioInstallDir is None:
       self.factorioExe:str = os.path.abspath(f"{self.__retrieveSteamGameInstallLocation(427520)}/bin/x64/factorio.exe")
     else:
@@ -16,7 +16,7 @@ class FactorioController:
       self.log:Callable[[str], None] = lambda msg : print(f"angelsdev-unit-test: {msg}")
     else:
       self.log:Callable[[str], None] = log
-    self.factorioArgs:list = self.__createFactorioArgs()
+    self.factorioArgs:list = self.__createFactorioArgs(factorioModDir)
     self.factorioProcess:Optional[subprocess.Popen] = None
 
   def launchGame(self) -> None:
@@ -137,7 +137,7 @@ class FactorioController:
 
     return steamGameFolder
 
-  def __createFactorioArgs(self) -> list:
+  def __createFactorioArgs(self, factorioModDir:Optional[str]=None) -> list:
     def convert_to_arglist(arg:str) -> list:
       return arg.split(' ')
 
@@ -145,7 +145,9 @@ class FactorioController:
     args.append(self.factorioExe) # because factorio expects the exe as first arg...
     #args.extend(convert_to_arglist("--verbose"))
     args.extend(convert_to_arglist(f"--load-scenario base/freeplay"))
-    #args.extend(convert_to_arglist(f"--mod-directory {os.path.abspath(os.getenv('APPDATA'))}/Factorio/mods/".replace("\\", "/")))
+    if factorioModDir != None:
+      args.append("--mod-directory")
+      args.append(factorioModDir)
     
     return args
 

--- a/angelsdev-unit-test/python/mod_builder.py
+++ b/angelsdev-unit-test/python/mod_builder.py
@@ -4,10 +4,12 @@ import json
 
 class ModBuilder:
 
-  def __init__(self, factorioFolderDir:Optional[str]=None):
+  def __init__(self, factorioFolderDir:Optional[str]=None, factorioModDir:Optional[str]=None):
     self.modNames = [modName for modName in next(os.walk(f"{os.path.dirname(os.path.abspath(__file__))}/../.."))[1] if self.__isReleased(modName)]
 
-    if factorioFolderDir is None:
+    if factorioModDir != None:
+      self.modFolderDir = factorioModDir
+    elif factorioFolderDir is None:
       self.modFolderDir = f"{os.getenv('APPDATA')}/Factorio/mods/"
     else:
       self.modFolderDir = f"{os.path.abspath(factorioFolderDir)}/mods/"

--- a/angelsdev-unit-test/python/modlist_controller.py
+++ b/angelsdev-unit-test/python/modlist_controller.py
@@ -6,8 +6,10 @@ class ModlistController:
   #   https://wiki.factorio.com/Mod_settings_file_format
   #   https://wiki.factorio.com/Property_tree
 
-  def __init__(self, factorioFolderDir=None):
-    if factorioFolderDir == None:
+  def __init__(self, factorioFolderDir=None, factorioModDir=None):
+    if factorioModDir != None:
+      self.modFolderDir = factorioModDir
+    elif factorioFolderDir == None:
       self.modFolderDir = f"{os.path.abspath(os.getenv('APPDATA'))}/Factorio/mods/"
     else:
       self.modFolderDir = f"{os.path.abspath(factorioFolderDir)}/mods/"
@@ -41,13 +43,17 @@ class ModlistController:
     self.modlist.append({ 'name': modname, 'enabled': True })
 
 if __name__ == "__main__":
-  factorioFolderDir = None
-  opts, args = getopt.getopt(sys.argv[1:], ":m:", ['dir='])
-  for opt, arg in opts:
-    if opt in ('-m', '--factoriodir'):
-      factorioFolderDir = os.path.realpath(arg.strip())
+  factorioFolderDir:Optional[str]=None
+  factorioModDir:Optional[str]=None
 
-  mc = ModlistController(factorioFolderDir)
+  opts, args = getopt.getopt(sys.argv[1:], "f:m:", ['factoriodir=', 'mod-directory='])
+  for opt, arg in opts:
+    if opt in ('-f', '--factoriodir'):
+      factorioFolderDir = os.path.realpath(arg.strip())
+    if opt in ('-m'):
+      factorioModDir = os.path.realpath(arg.strip())
+
+  mc = ModlistController(factorioFolderDir, factorioModDir)
   mc.readConfigurationFile()
   mc.disableAllMods()
   mc.enableMod("angelsinfiniteores")

--- a/angelsdev-unit-test/python/modlist_controller.py
+++ b/angelsdev-unit-test/python/modlist_controller.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
   for opt, arg in opts:
     if opt in ('-f', '--factoriodir'):
       factorioFolderDir = os.path.realpath(arg.strip())
-    if opt in ('-m'):
+    if opt in ('-m', '--mod-directory'):
       factorioModDir = os.path.realpath(arg.strip())
 
   mc = ModlistController(factorioFolderDir, factorioModDir)

--- a/angelsdev-unit-test/python/settings_controller.py
+++ b/angelsdev-unit-test/python/settings_controller.py
@@ -221,7 +221,7 @@ if __name__ == "__main__":
   for opt, arg in opts:
     if opt in ('-f', '--factoriodir'):
       factorioFolderDir = os.path.realpath(arg.strip())
-    if opt in ('-m'):
+    if opt in ('-m', '--mod-directory'):
       factorioModDir = os.path.realpath(arg.strip())
 
   sc = SettingsController(factorioFolderDir, factorioModDir)

--- a/angelsdev-unit-test/python/settings_controller.py
+++ b/angelsdev-unit-test/python/settings_controller.py
@@ -130,8 +130,10 @@ class SettingsController:
   #   https://wiki.factorio.com/Mod_settings_file_format
   #   https://wiki.factorio.com/Property_tree
 
-  def __init__(self, factorioFolderDir=None):
-    if factorioFolderDir == None:
+  def __init__(self, factorioFolderDir=None, factorioModDir=None):
+    if factorioModDir != None:
+      self.modFolderDir = factorioModDir
+    elif factorioFolderDir == None:
       self.modFolderDir = f"{os.path.abspath(os.getenv('APPDATA'))}/Factorio/mods/"
     else:
       self.modFolderDir = f"{os.path.abspath(factorioFolderDir)}/mods/"
@@ -212,13 +214,17 @@ class SettingsController:
     modSettingStage[len(modSettingStage.keys())] = [settingName, { 0 : ['value', settingValue] }]
 
 if __name__ == "__main__":
-  factorioFolderDir = None
-  opts, args = getopt.getopt(sys.argv[1:], ":m:", ['dir='])
-  for opt, arg in opts:
-    if opt in ('-m', '--factoriodir'):
-      factorioFolderDir = os.path.realpath(arg.strip())
+  factorioFolderDir:Optional[str]=None
+  factorioModDir:Optional[str]=None
 
-  sc = SettingsController(factorioFolderDir)
+  opts, args = getopt.getopt(sys.argv[1:], "f:m:", ['factoriodir=', 'mod-directory='])
+  for opt, arg in opts:
+    if opt in ('-f', '--factoriodir'):
+      factorioFolderDir = os.path.realpath(arg.strip())
+    if opt in ('-m'):
+      factorioModDir = os.path.realpath(arg.strip())
+
+  sc = SettingsController(factorioFolderDir, factorioModDir)
   sc.readSettingsFile()
   sc.setSettingValue("startup", "angels-enable-industries", True) # angels override
   sc.writeSettingsFile("mod-settings-dupe.dat")

--- a/angelsdev-unit-test/python/unit_test_controller.py
+++ b/angelsdev-unit-test/python/unit_test_controller.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
       factorioInstallDir = os.path.realpath(arg.strip())
     if opt in ('-l'):
       logToFile = True
-    if opt in ('-m'):
+    if opt in ('-m', '--mod-directory'):
       factorioModDir = os.path.realpath(arg.strip())
 
   UnitTestController(updateMods=False, factorioInstallDir=factorioInstallDir, factorioFolderDir=factorioFolderDir, logToFile=logToFile, factorioModDir=factorioModDir).TestConfiguations(UnitTestConfiguration())

--- a/angelsdev-unit-test/python/unit_test_controller.py
+++ b/angelsdev-unit-test/python/unit_test_controller.py
@@ -12,7 +12,7 @@ from unit_test_logger import UnitTestLogger
 
 class UnitTestController:
 
-  def __init__(self:UnitTestController, updateMods:bool=True, factorioInstallDir:Optional[str]=None, factorioFolderDir:Optional[str]=None, logToFile:bool=False):
+  def __init__(self:UnitTestController, updateMods:bool=True, factorioInstallDir:Optional[str]=None, factorioFolderDir:Optional[str]=None, logToFile:bool=False, factorioModDir:Optional[str]=None):
     if factorioFolderDir is None:
       self.factorioFolderDir:str = os.path.abspath(f"{os.getenv('APPDATA')}/Factorio/")
     else:
@@ -23,18 +23,18 @@ class UnitTestController:
       self.__buildBobsMods()
 
     # Backup the current mod config and mod settings
-    self.currentModlistController = ModlistController(self.factorioFolderDir)
+    self.currentModlistController = ModlistController(self.factorioFolderDir, factorioModDir)
     self.currentModlistController.readConfigurationFile()
-    self.currentSettingsController = SettingsController(self.factorioFolderDir)
+    self.currentSettingsController = SettingsController(self.factorioFolderDir, factorioModDir)
     self.currentSettingsController.readSettingsFile()
 
     # Logger for unit test output
     self.logger = UnitTestLogger(logToFile)
 
     # New controllers for the unit tests
-    self.modlistController = ModlistController(self.factorioFolderDir)
-    self.settingsController = SettingsController(self.factorioFolderDir)
-    self.factorioController = FactorioController(factorioInstallDir, self.logger)
+    self.modlistController = ModlistController(self.factorioFolderDir, factorioModDir)
+    self.settingsController = SettingsController(self.factorioFolderDir, factorioModDir)
+    self.factorioController = FactorioController(factorioInstallDir, self.logger, factorioModDir)
     
 
   def __del__(self:UnitTestController):
@@ -112,9 +112,10 @@ class UnitTestController:
 if __name__ == "__main__":
   factorioFolderDir:Optional[str]=None
   factorioInstallDir:Optional[str]=None
+  factorioModDir:Optional[str]=None
   logToFile:bool=False
 
-  opts, args = getopt.getopt(sys.argv[1:], "f:i:l:", ['factoriodir=', 'installdir='])
+  opts, args = getopt.getopt(sys.argv[1:], "f:i:l:m:", ['factoriodir=', 'installdir=', 'mod-directory='])
   for opt, arg in opts:
     if opt in ('-f', '--factoriodir'):
       factorioFolderDir = os.path.realpath(arg.strip())
@@ -122,5 +123,7 @@ if __name__ == "__main__":
       factorioInstallDir = os.path.realpath(arg.strip())
     if opt in ('-l'):
       logToFile = True
+    if opt in ('-m'):
+      factorioModDir = os.path.realpath(arg.strip())
 
-  UnitTestController(updateMods=False, factorioInstallDir=factorioInstallDir, factorioFolderDir=factorioFolderDir, logToFile=logToFile).TestConfiguations(UnitTestConfiguration())
+  UnitTestController(updateMods=False, factorioInstallDir=factorioInstallDir, factorioFolderDir=factorioFolderDir, logToFile=logToFile, factorioModDir=factorioModDir).TestConfiguations(UnitTestConfiguration())

--- a/run_unit_tests.bat
+++ b/run_unit_tests.bat
@@ -1,6 +1,6 @@
 @echo off
 pushd %~dp0\angelsdev-unit-test\python\
-python unit_test_controller.py -l --factoriodir="C:\Users\User\AppData\Roaming\Factorio" --installdir="D:\Laurens\Steam\steamapps\common\Factorio"
+python unit_test_controller.py -l "" --factoriodir="C:\Users\User\AppData\Roaming\Factorio" --installdir="D:\Laurens\Steam\steamapps\common\Factorio"
 popd
 PAUSE
 


### PR DESCRIPTION
Add additional (optional) command line parameter to the python unit test runner.
Allow mod directory to be specified.