### PR TITLE
Science Overhaul Tech Modifier

### DIFF
--- a/angelsbioprocessing/changelog.txt
+++ b/angelsbioprocessing/changelog.txt
@@ -13,6 +13,7 @@ Date: ##.##.2022
       - Desert farming 2
       - Swamp farming environment
       - Swamp farming 2
+    - Changed technologies Basic algae processing and Paper making 1 to ignore tech cost modifier (820)
   Bugfixes:
     - Fixed fishes prevented landfill from being blueprinted on water (815)
 ---------------------------------------------------------------------------------------------------

--- a/angelsbioprocessing/prototypes/overrides/bio-processing-override-bob.lua
+++ b/angelsbioprocessing/prototypes/overrides/bio-processing-override-bob.lua
@@ -54,3 +54,8 @@ if bobmods then
     { name = "bob-coal-from-wood", ingredients = { {type="item", name="wood", amount = 5} } },
   })
 end
+
+if mods["bobassembly"] and settings.startup["bobmods-assembly-burner"].value == true then
+  OV.remove_prereq("bio-processing-brown", "automation")
+  OV.add_prereq("bio-processing-brown", "basic-automation")
+end

--- a/angelsbioprocessing/prototypes/technology/bio-processing-algae.lua
+++ b/angelsbioprocessing/prototypes/technology/bio-processing-algae.lua
@@ -33,7 +33,8 @@ data:extend(
           {type = "item", name = "automation-science-pack", amount = 1}
         },
         time = 30
-      }
+      },
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",

--- a/angelsbioprocessing/prototypes/technology/bio-processing-wood-paper.lua
+++ b/angelsbioprocessing/prototypes/technology/bio-processing-wood-paper.lua
@@ -619,7 +619,7 @@ data:extend(
         {type="item", name="token-bio", amount = 1}
       },
       time = 30
-    },
+    }
   },
   {
     type = "technology",
@@ -650,6 +650,7 @@ data:extend(
       },
       time = 30
     },
+    ignore_tech_cost_multiplier = true
   },
   {
     type = "technology",

--- a/angelsindustries/changelog.txt
+++ b/angelsindustries/changelog.txt
@@ -1,4 +1,14 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.4.17
+Date: ##.##.2022
+  Changes:
+    - Science mode:
+      - Changed technologies that are researched in tech Tech archive to ignore tech cost modifier (820)
+      - Removed Alien plant-life sample from technologies Fermentation processes and Temperate arboretum 1 (820)
+      - Added Miniloader support (820)
+      - Made Nanobots available sooner (820)
+      - When Bob's Assemling machines mod is enabled, Stone filtering furnace is unlocked by technology Basic automation  (820)
+---------------------------------------------------------------------------------------------------
 Version: 0.4.16
 Date: 06.06.2022
   Changes:

--- a/angelsindustries/info.json
+++ b/angelsindustries/info.json
@@ -1,6 +1,6 @@
 {
   "name": "angelsindustries",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "factorio_version": "1.1",
   "title": "Angel's Industries",
   "author": "Arch666Angel",

--- a/angelsindustries/prototypes/overrides/global-tech-base-packs.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-base-packs.lua
@@ -52,8 +52,10 @@ if angelsmods.industries.tech then
   AI.pack_count_update("bio-temperate-farming", "angels-science-pack-red", 4)
   AI.pack_replace("bio-fermentation", "green", "red")
   OV.remove_prereq("bio-fermentation", "tech-green-packs")
+  OV.remove_science_pack("bio-fermentation", "token-bio")
   AI.pack_replace("bio-arboretum-temperate-1", "green", "red")
   OV.remove_prereq("bio-arboretum-temperate-1", "resins")
+  OV.remove_science_pack("bio-arboretum-temperate-1", "token-bio")
   OV.add_prereq("bio-arboretum-temperate-2", "resins")
   -- INDUSTRIES
   AI.pack_replace("tech-green-circuit", "green", "red")

--- a/angelsindustries/prototypes/overrides/global-tech-base-packs.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-base-packs.lua
@@ -210,6 +210,9 @@ if angelsmods.industries.tech then
   OV.set_science_pack("rocket-silo", "angels-science-pack-green")
   OV.set_science_pack("rocket-silo", "angels-science-pack-orange")
   OV.set_science_pack("rocket-silo", "angels-science-pack-blue")
+  if data.raw.technology["rocket-silo"] then
+    data.raw.technology["rocket-silo"].ignore_tech_cost_multiplier = true
+  end
   -- REFINING
   AI.pack_replace("advanced-ore-refining-4", "blue", "yellow")
   -- BIO PROCESSING

--- a/angelsindustries/prototypes/overrides/global-tech-bobs-packs.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-bobs-packs.lua
@@ -44,8 +44,6 @@ if angelsmods.industries.tech then
     if settings.startup["bobmods-assembly-burner"].value == true then
       AI.pack_replace("basic-automation", "red", "grey")
       AI.pack_replace("automation", "grey", "red")
-      OV.remove_prereq("bio-processing-brown", "automation")
-      OV.add_prereq("bio-processing-brown", "basic-automation")
     end
     -- assemblers tier 2+
     AI.pack_replace("automation-4", "blue", "orange")

--- a/angelsindustries/prototypes/overrides/global-tech-popular-addons.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-popular-addons.lua
@@ -27,7 +27,6 @@ if angelsmods.industries.tech then
   -------------------------------------------------------------------------------
   if mods["Nanobots"] then
     AI.pack_replace("nanobots", "red", "grey")
-    OV.add_prereq("nanobots", "tech-red-circuit")
     if mods["boblogistics"] then
       OV.remove_prereq("nanobots", "logistics")
       OV.add_prereq("nanobots", "logistics-0")

--- a/angelsindustries/prototypes/overrides/global-tech-popular-addons.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-popular-addons.lua
@@ -60,6 +60,24 @@ if angelsmods.industries.tech then
     OV.remove_prereq("nano-range-4", "robotics")
     OV.add_prereq("nano-range-4", "angels-components-mechanical-5")
   end
-  
+
+  -------------------------------------------------------------------------------
+  -- MINILOADER -----------------------------------------------------------------
+  -------------------------------------------------------------------------------
+  if mods["miniloader"] then
+    AI.core_replace("miniloader", "basic", "logistic")
+    AI.core_replace("fast-miniloader", "basic", "logistic")
+    AI.core_replace("express-miniloader", "basic", "logistic")
+    OV.remove_science_pack("express-miniloader", "production-science-pack")
+    if mods["boblogistics"] then
+      AI.pack_replace("basic-miniloader", "red", "grey")
+      AI.pack_replace("express-miniloader", "blue", "orange")
+      AI.core_replace("turbo-miniloader", "basic", "logistic")
+      AI.core_replace("ultimate-miniloader", "basic", "logistic")
+      OV.remove_science_pack("turbo-miniloader", "production-science-pack")
+      OV.remove_science_pack("ultimate-miniloader", "production-science-pack")
+    end
+  end
+
   OV.execute()
 end

--- a/angelsindustries/prototypes/technology/tech-lab-technology.lua
+++ b/angelsindustries/prototypes/technology/tech-lab-technology.lua
@@ -37,7 +37,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -64,7 +65,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -92,7 +94,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -129,7 +132,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -158,7 +162,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     -----------------------------------------------------------------------------
     -- ENERGY LABS --------------------------------------------------------------
@@ -193,7 +198,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -220,7 +226,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -248,7 +255,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -285,7 +293,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -314,7 +323,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     -----------------------------------------------------------------------------
     -- LOGISTICS LABS -----------------------------------------------------------
@@ -349,7 +359,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -376,7 +387,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -404,7 +416,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -441,7 +454,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -470,7 +484,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     -----------------------------------------------------------------------------
     -- ENHANCEMENT LABS ---------------------------------------------------------
@@ -505,7 +520,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -532,7 +548,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -560,7 +577,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -597,7 +615,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -626,7 +645,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     -----------------------------------------------------------------------------
     -- PRODUCTION LABS ----------------------------------------------------------
@@ -662,7 +682,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -689,7 +710,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -718,7 +740,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -756,7 +779,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -786,7 +810,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     -----------------------------------------------------------------------------
     -- WARFARE LABS -------------------------------------------------------------
@@ -822,7 +847,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -850,7 +876,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -879,7 +906,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -917,7 +945,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -947,7 +976,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     -----------------------------------------------------------------------------
     -- BASIC LABS ---------------------------------------------------------------
@@ -975,7 +1005,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     {
       type = "technology",
@@ -1004,7 +1035,8 @@ data:extend(
         },
         time = pack_time_base
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     },
     -----------------------------------------------------------------------------
     -- POST ROCKET LABS ---------------------------------------------------------
@@ -1061,7 +1093,8 @@ data:extend(
         time = pack_time_base
         --pack_time_base,
       },
-      order = "b-5"
+      order = "b-5",
+      ignore_tech_cost_multiplier = true
     }
   }
 )

--- a/angelsindustries/prototypes/technology/tech-pack-technology.lua
+++ b/angelsindustries/prototypes/technology/tech-pack-technology.lua
@@ -29,7 +29,8 @@ if angelsmods.industries.tech then
           },
           time = pack_time_base
         },
-        order = "a-5"
+        order = "a-5",
+        ignore_tech_cost_multiplier = true
       },
       --TIER 2
       {
@@ -63,7 +64,8 @@ if angelsmods.industries.tech then
           },
           time = pack_time_base
         },
-        order = "a-5"
+        order = "a-5",
+        ignore_tech_cost_multiplier = true
       },
       --TIER 2.5
       {
@@ -94,7 +96,8 @@ if angelsmods.industries.tech then
           },
           time = pack_time_base
         },
-        order = "a-5"
+        order = "a-5",
+        ignore_tech_cost_multiplier = true
       },
       --TIER 3
       {
@@ -130,7 +133,8 @@ if angelsmods.industries.tech then
           },
           time = pack_time_base
         },
-        order = "a-5"
+        order = "a-5",
+        ignore_tech_cost_multiplier = true
       },
       --TIER 4
       {
@@ -163,7 +167,8 @@ if angelsmods.industries.tech then
           },
           time = pack_time_base
         },
-        order = "a-5"
+        order = "a-5",
+        ignore_tech_cost_multiplier = true
       }
     }
   )

--- a/angelsrefining/prototypes/override-functions.lua
+++ b/angelsrefining/prototypes/override-functions.lua
@@ -816,6 +816,9 @@ end
 
 local function adjust_technology(tech, k) -- check a tech for basic adjustments based on tables and make any necessary changes
   local function override_subtable(subtable, o_subtable) -- handle special case changes (sort of a partial deep copy/overwrite)
+    if type(o_subtable) == "string" then
+      o_subtable = {o_subtable}
+    end
     for ok, ov in pairs(o_subtable) do
       if type(ov) == "table" then
         if not subtable[ok] then
@@ -903,7 +906,11 @@ local function adjust_technology(tech, k) -- check a tech for basic adjustments 
   end
   local overrides = override_table.technologies[k]
   if overrides then
-    override_subtable(tech, overrides)
+    if type(overrides) =="string" then
+      tech[overrides] = (not tech[overrides]) or true
+    else
+      override_subtable(tech, overrides)
+    end
   end
   --adjust difficulty (time and amount of ingredients)
   if modify_table.technologies[k] then

--- a/angelsrefining/prototypes/override-functions.lua
+++ b/angelsrefining/prototypes/override-functions.lua
@@ -302,7 +302,13 @@ ov_functions.disable_technology = function(technology) -- disable technology (ma
 end
 
 ov_functions.set_special_technology_override = function(technology, t)
-  override_table.technologies[technology] = t
+  if type(technology) =="table" then
+    for _,tech in pairs(technology) do
+      override_table.technologies[tech] = t
+    end
+  else
+    override_table.technologies[technology] = t
+  end
 end
 
 -------------------------------------------------------------------------------

--- a/angelssmelting/prototypes/override/smelting-override-alloy-support.lua
+++ b/angelssmelting/prototypes/override/smelting-override-alloy-support.lua
@@ -43,7 +43,11 @@ if mods["bobplates"] then
 
   if mods["bobassembly"] and settings.startup["bobmods-assembly-multipurposefurnaces"].value then
     -- keep metal mixing furnaces around
-    OV.add_unlock("automation", "stone-mixing-furnace")
+    if mods["bobassembly"] and settings.startup["bobmods-assembly-burner"].value == true then
+      OV.add_unlock("basic-automation", "stone-mixing-furnace")
+    else
+      OV.add_unlock("automation", "stone-mixing-furnace")
+    end
     OV.patch_recipes({
       {
         name = "electric-chemical-mixing-furnace",


### PR DESCRIPTION
Fixes #820

### Archive Techs
With Science Overhaul, can only have one Tech archive. Because of this, any tech researched in the archive should ignore tech cost modifier.
- Basic Technology
- Red science: automation
- Basic exploration technology 1
- etc
- Rocket silo

### Grey Boards
At the start of the game, grey boards can be made from wood. Paper making is required to automate them.

Make techs ignore tech cost modifier:
- Basic algae processing
- Paper making 1

With "Bob's Assembling machines mod" enabled and "Burner and steam assembling machines" setting enabled, Automation will no long ignore tech cost modifier.
- Make Basic Algae Processing depend on Basic Automation when available.

### Stone filtering furnace
Stone filtering furnace should be unlocked by Basic automation, when tech is present. Rather than unlocked by Automation.

### Nanobots
Remove red electronics prerequisite from Nanobots. Nanobots don't use anything unlocked by that tech.

![image](https://user-images.githubusercontent.com/59639/188429495-858d49c4-b254-4406-9c5d-b37819ca7d74.png)

### Miniloader
- Swap Basic mini loader from red to grey
- Swap Express mini loader from blue to orange
- Swap techs to use Logistic cores

![image](https://user-images.githubusercontent.com/59639/188430488-ecccee3b-59cd-47b1-9845-7c8b244ffe96.png)

### Green science
Recipes for duplication of gardens / alien plant life samples is unlocked by Alien farming (green science). Green science has two prerequisite techs that require Alien plant life samples.
- Remove alien plant life samples from Fermentation processes and Temperate arboretum 1

![image](https://user-images.githubusercontent.com/59639/188448385-9bee665a-d52a-41d6-bb11-1923ec829456.png)

![image](https://user-images.githubusercontent.com/59639/188447995-bd711966-c55a-4d30-aa5f-93c90049dab6.png)
