### PR TITLE
Remove disabled recipes from expensive, normal mode effects of technologies too

### DIFF
--- a/angelsrefining/prototypes/override-functions.lua
+++ b/angelsrefining/prototypes/override-functions.lua
@@ -864,6 +864,25 @@ local function adjust_technology(tech, k) -- check a tech for basic adjustments 
       end
     end
   end
+  -- Also remove disabled recipes from the expensive and normal results tables.
+  for _, mode in pairs({"expensive", "normal"}) do
+    if tech[mode] and tech[mode].effects then
+      for ek, effect in pairs(tech[mode].effects) do
+        if effect.type == "unlock-recipe" then
+          if disable_table.recipes[effect.recipe] or (modifications and modifications[effect.recipe] == false) then
+            to_remove[ek] = true
+          else
+            dup_table[effect.recipe] = true
+          end
+        end
+      end
+      for ek = #tech[mode].effects, 1, -1 do
+        if to_remove[ek] then
+          table.remove(tech[mode].effects, ek)
+        end
+      end
+    end
+  end
   if modifications then
     if not tech.effects then
       tech.effects = {}


### PR DESCRIPTION
When a recipe is disabled it is only removed from the default `effects` table in technologies. They are now also removed from the `effects` table in the expensive and normal modes if they exist.

Not a massive fan of the code copying here, but I figured it was better than trying to generalise this code over all three options.

I need this for compact for my mod, which synthesises expensive and normal modes for technologies it touches.

I was able to start the game and generate and open a map in 1.1.70. I was not able to figure out how to run the unit tests. I can do that if anyone can explain or point me to an explanation.