### PR TITLE
Create trigger for Ammonium chloride gas

### DIFF
--- a/angelspetrochem/data.lua
+++ b/angelspetrochem/data.lua
@@ -15,6 +15,7 @@ angelsmods.trigger.resin = not (angelsmods.functions.is_special_vanilla() or not
 angelsmods.trigger.rubber = not (angelsmods.functions.is_special_vanilla() or not mods["bobelectronics"])
 angelsmods.trigger.liquid_ferric_chloride_solution = mods["bobelectronics"] and true or false
 angelsmods.trigger.liquid_cupric_chloride_solution = false
+angelsmods.trigger.gas_ammonium_chloride = false
 angelsmods.trigger.early_sulfuric_acid = false
 angelsmods.trigger.gas_hydrogen_fluoride = settings.startup["angels-enable-acids"].value
   or (mods["angelsbioprocessing"] and true or false)

--- a/angelspetrochem/prototypes/global-override/bobrevamp.lua
+++ b/angelspetrochem/prototypes/global-override/bobrevamp.lua
@@ -154,7 +154,6 @@ if mods["bobrevamp"] then
       angelsmods.functions.add_flag("sodium-perchlorate", "hidden")
 
       OV.disable_recipe({ "ammonium-chloride-recycling" })
-      OV.converter_fluid("ammonium-chloride", "gas-ammonium-chloride")
       angelsmods.functions.add_flag("ammonium-chloride", "hidden")
     end
   end

--- a/angelspetrochem/prototypes/override/angelspetrochem.lua
+++ b/angelspetrochem/prototypes/override/angelspetrochem.lua
@@ -188,13 +188,11 @@ if angelsmods.functions.is_special_vanilla() then
     "solid-calcium-chloride",
     "cumene-process", -- "gas-acetone"
     "gas-phosgene",
-    "gas-ammonium-chloride",
   })
   OV.remove_prereq("angels-nitrogen-processing-2", "chlorine-processing-1")
   angelsmods.functions.add_flag({
     "solid-calcium-chloride",
     "gas-phosgene",
-    "gas-ammonium-chloride",
   }, "hidden")
 
   if angelsmods.bioprocessing then
@@ -271,6 +269,22 @@ else
   })
   OV.remove_unlock("chlorine-processing-1", "liquid-cupric-chloride-solution")
   angelsmods.functions.add_flag("liquid-cupric-chloride-solution", "hidden")
+end
+
+if angelsmods.trigger.smelting_products["platinum"].ingot
+  or angelsmods.trigger.smelting_products["platinum"].plate
+  or angelsmods.trigger.smelting_products["platinum"].powder
+  or angelsmods.trigger.smelting_products["platinum"].wire
+then
+  angelsmods.trigger.gas_ammonium_chloride = true
+end
+if angelsmods.trigger.gas_ammonium_chloride then
+else
+  OV.disable_recipe({
+    "gas-ammonium-chloride",
+  })
+  OV.remove_unlock("angels-nitrogen-processing-2", "gas-ammonium-chloride")
+  angelsmods.functions.add_flag("gas-ammonium-chloride", "hidden")
 end
 
 -----------------------------------------------------------------------------

--- a/angelspetrochem/prototypes/override/angelspetrochem.lua
+++ b/angelspetrochem/prototypes/override/angelspetrochem.lua
@@ -271,10 +271,11 @@ else
   angelsmods.functions.add_flag("liquid-cupric-chloride-solution", "hidden")
 end
 
-if angelsmods.trigger.smelting_products["platinum"].ingot
+if angelsmods.trigger.smelting_products["platinum"]
+  and (angelsmods.trigger.smelting_products["platinum"].ingot
   or angelsmods.trigger.smelting_products["platinum"].plate
   or angelsmods.trigger.smelting_products["platinum"].powder
-  or angelsmods.trigger.smelting_products["platinum"].wire
+  or angelsmods.trigger.smelting_products["platinum"].wire)
 then
   angelsmods.trigger.gas_ammonium_chloride = true
 end

--- a/angelssmelting/prototypes/override/smelting-override-platinum.lua
+++ b/angelssmelting/prototypes/override/smelting-override-platinum.lua
@@ -41,9 +41,8 @@ else
   angelsmods.functions.add_flag("solid-ammonium-chloroplatinate", "hidden")
   angelsmods.functions.add_flag("ingot-platinum", "hidden")
   angelsmods.functions.add_flag("liquid-molten-platinum", "hidden")
-  angelsmods.functions.add_flag("gas-ammonium-chloride", "hidden")
   OV.disable_recipe({ "platinum-ore-processing", "platinum-processed-processing" })
-  OV.disable_recipe({ "pellet-platinum-smelting", "liquid-hexachloroplatinic-acid-smelting", "gas-ammonium-chloride" })
+  OV.disable_recipe({ "pellet-platinum-smelting", "liquid-hexachloroplatinic-acid-smelting" })
   OV.disable_recipe({
     "platinum-ore-smelting",
     "processed-platinum-smelting",


### PR DESCRIPTION
Ammonium Chloride was not used and also not disabled when Smelting mod is disabled.

Bob's Ammonium Chloride is an item, not a fluid. So don't try create a converter recipe.
