### PR TITLE
Fix oil refinery recipe icons

### DIFF
--- a/angelspetrochem/changelog.txt
+++ b/angelspetrochem/changelog.txt
@@ -46,6 +46,7 @@ Date: ##.##.2022
       - The oil refining and the gas fractioning recipe icons are slightly altered to reflect the fluid layout of their respective recipe.
   Bugfixes:
     - Fixed machine output arrows (839)
+    - Make Oil refineries scale their recipe icons to match vanilla (874)
 ---------------------------------------------------------------------------------------------------
 Version: 0.9.22
 Date: 06.06.2022

--- a/angelspetrochem/prototypes/buildings/oil-refinery.lua
+++ b/angelspetrochem/prototypes/buildings/oil-refinery.lua
@@ -47,6 +47,7 @@ data:extend({
     module_specification = {
       module_slots = 2,
     },
+    scale_entity_info_icon = true,
     allowed_effects = { "consumption", "speed", "productivity", "pollution" },
     crafting_categories = { "oil-processing" },
     crafting_speed = 1.5,
@@ -201,6 +202,7 @@ data:extend({
     module_specification = {
       module_slots = 2,
     },
+    scale_entity_info_icon = true,
     allowed_effects = { "consumption", "speed", "productivity", "pollution" },
     crafting_categories = { "oil-processing" },
     crafting_speed = 2,
@@ -354,6 +356,7 @@ data:extend({
     module_specification = {
       module_slots = 2,
     },
+    scale_entity_info_icon = true,
     allowed_effects = { "consumption", "speed", "productivity", "pollution" },
     crafting_categories = { "oil-processing" },
     crafting_speed = 2.5,


### PR DESCRIPTION
Make Angel's Oil Refineries scale recipe icons. This change brings them into line with the vanilla Oil Refinery.

![image](https://user-images.githubusercontent.com/59639/206407974-e4d429ef-12a1-4e42-a083-11ffa973b60c.png)
