### PR TITLE
Fix crystal slurry filtering conversion 2

### DIFF
--- a/angelsrefining/changelog.txt
+++ b/angelsrefining/changelog.txt
@@ -22,6 +22,7 @@ Date: ???
       - Made some mineral sludge crystallization recipe require Crystallizer 2
       - Made crystal catalyst recipe require Crystallizer 2
       - Made hybrid catalyst recipe require Crystallizer 3
+    - Reduces crystal-slurry-filtering-conversion-2 min water requirements
   Bugfixes:
     - Fixed machine output arrows (839)
     - Fixed error when patching a recipe with variable result products (835)

--- a/angelsrefining/prototypes/recipes/refining-static.lua
+++ b/angelsrefining/prototypes/recipes/refining-static.lua
@@ -1477,7 +1477,7 @@ data:extend({
     enabled = false,
     ingredients = {
       { type = "fluid", name = "crystal-slurry", amount = 35 },
-      { type = "fluid", name = "water-mineralized", amount = 100 },
+      { type = "fluid", name = "water-mineralized", amount = 70 },
       { type = "item", name = "filter-ceramic", amount = 1 },
     },
     results = {


### PR DESCRIPTION
The mineral-sludge recipe via washing and charcoal filtering is balanced. When crushing all geodes, there is a bit excess mineralized water.

Ceramic filtering needs a lot of extra mineralized water, which makes the recipe unusable.
Slag slurry ceramic filtering is just using purified water, which can be easily added.

![image](https://user-images.githubusercontent.com/9379708/209823963-7bbb46a4-fa33-44e3-8bbd-b3eff551d57e.png)
One is ceramic one is coal filtering. Ceramic has excess crystal dust, or in other words not enough crushed stone to keep the process running.
If we change the required 100 to 70, the ratio would be correct and the recipe would be useful. At the moment, the ceramic crystal slurry recipe could be deleted.

![image](https://user-images.githubusercontent.com/9379708/209822963-7f7510c9-250b-43b3-860c-f8ae2e12b035.png)
![image](https://user-images.githubusercontent.com/9379708/209823043-a4b53b87-964a-4e0e-8058-e40901fe7294.png)

