### PR TITLE
Components & Technology Overhaul Fixes

### DIFF
--- a/angelsindustries/changelog.txt
+++ b/angelsindustries/changelog.txt
@@ -6,6 +6,7 @@ Date: xx.xx.xxxx
       - Fixed Item Subgroup of Heat Exchanger 4 from Bob's Power (887)
     - Component mode:
       - Fixed the silver-zinc battery did not require a battery casing (886)
+      - Fixed ingredients and tech prerequisites of radar from Bob's Warfare (889)
 ---------------------------------------------------------------------------------------------------
 Version: 0.4.17
 Date: 01.01.2023

--- a/angelsindustries/changelog.txt
+++ b/angelsindustries/changelog.txt
@@ -5,6 +5,7 @@ Date: xx.xx.xxxx
     - Regular mode:
       - Fixed Item Subgroup of Heat Exchanger 4 from Bob's Power (887)
     - Component mode:
+      - Fixed splitter circuit board tiers (636)
       - Fixed the silver-zinc battery did not require a battery casing (886)
       - Fixed ingredients and tech prerequisites of radar from Bob's Warfare (889)
 ---------------------------------------------------------------------------------------------------

--- a/angelsindustries/prototypes/overrides/components-base-recipe-update.lua
+++ b/angelsindustries/prototypes/overrides/components-base-recipe-update.lua
@@ -155,6 +155,22 @@ if angelsmods.industries.components then
     OV.add_prereq("productivity-module-2", "tech-blue-circuit")
     OV.add_prereq("productivity-module-3", "tech-yellow-circuit")
   end
+
+  -- splitters
+  OV.patch_recipes({
+    {
+      name = "fast-splitter",
+      ingredients = {
+        { type = "item", name = "circuit-green-loaded", amount = "circuit-red-loaded" },
+      },
+    },
+    {
+      name = "express-splitter",
+      ingredients = {
+        { type = "item", name = "circuit-blue-loaded", amount = "circuit-orange-loaded" },
+      },
+    },
+  })
 end
 
 if angelsmods.industries.components then

--- a/angelsindustries/prototypes/overrides/components-bobs-entity-update/components-bobs-radar-update.lua
+++ b/angelsindustries/prototypes/overrides/components-bobs-entity-update/components-bobs-radar-update.lua
@@ -1,0 +1,73 @@
+if angelsmods.industries.components then
+  local OV = angelsmods.functions.OV
+
+  if mods["bobwarfare"] then
+    -- radar
+    OV.patch_recipes({
+      {
+        name = "radar",
+        ingredients = {
+          { "!!" },
+          { type = "item", name = "block-electronics-1", amount = 2 },
+          { type = "item", name = "block-construction-1", amount = 5 },
+          { type = "item", name = "block-enhancement-1", amount = 1 },
+          { type = "item", name = "block-mechanical-1", amount = 1 },
+        },
+      },
+      {
+        name = "radar-2",
+        ingredients = {
+          { "!!" },
+          { type = "item", name = "block-electronics-2", amount = 2 },
+          { type = "item", name = "block-construction-2", amount = 5 },
+          { type = "item", name = "block-enhancement-2", amount = 1 },
+          { type = "item", name = "block-mechanical-1", amount = 1 },
+        },
+      },
+      {
+        name = "radar-3",
+        ingredients = {
+          { "!!" },
+          { type = "item", name = "block-electronics-3", amount = 2 },
+          { type = "item", name = "block-construction-3", amount = 5 },
+          { type = "item", name = "block-enhancement-3", amount = 1 },
+          { type = "item", name = "block-mechanical-2", amount = 1 },
+        },
+      },
+      {
+        name = "radar-4",
+        ingredients = {
+          { "!!" },
+          { type = "item", name = "block-electronics-4", amount = 2 },
+          { type = "item", name = "block-construction-4", amount = 5 },
+          { type = "item", name = "block-enhancement-4", amount = 1 },
+          { type = "item", name = "block-mechanical-2", amount = 1 },
+        },
+      },
+      {
+        name = "radar-5",
+        ingredients = {
+          { "!!" },
+          { type = "item", name = "block-electronics-5", amount = 2 },
+          { type = "item", name = "block-construction-5", amount = 5 },
+          { type = "item", name = "block-enhancement-5", amount = 1 },
+          { type = "item", name = "block-mechanical-2", amount = 1 },
+        },
+      },
+    })
+
+    OV.add_prereq("radars-1", "angels-basic-blocks-1")
+    OV.add_prereq("radars-2", "angels-basic-blocks-2")
+    OV.add_prereq("radars-3", "angels-components-weapons-advanced")
+    OV.add_prereq("radars-4", "military-3")
+    OV.add_prereq("radars-4", "angels-advanced-blocks-1")
+    OV.add_prereq("radars-5", "angels-advanced-blocks-2")
+
+    OV.remove_prereq("radars-2", "electronics")
+    OV.remove_prereq("radars-3", "military-3")
+    OV.remove_prereq("radars-3", "zinc-processing")
+    OV.remove_prereq("radars-4", "titanium-processing")
+    OV.remove_prereq("radars-5", "advanced-electronics-3")
+    OV.remove_prereq("radars-4", "nitinol-processing")
+  end
+end

--- a/angelsindustries/prototypes/overrides/components-bobs-recipe-update.lua
+++ b/angelsindustries/prototypes/overrides/components-bobs-recipe-update.lua
@@ -113,6 +113,37 @@ if angelsmods.industries.components then
   end
 
   -----------------------------------------------------------------------------
+  -- BOB LOGISTICS ------------------------------------------------------------
+  -----------------------------------------------------------------------------
+  if mods["boblogistics"] then
+    -- splitters
+    if settings.startup["bobmods-logistics-beltoverhaul"].value == true then
+      OV.patch_recipes({
+        {
+          name = "basic-splitter",
+          ingredients = {
+            { type = "item", name = "circuit-grey", amount = "copper-cable" },
+          },
+        },
+        {
+          name = "splitter",
+          ingredients = {
+            { type = "item", name = "circuit-red-loaded", amount = "circuit-grey" },
+          },
+        },
+      })
+    end
+    OV.patch_recipes({
+      {
+        name = "express-splitter",
+        ingredients = {
+          { type = "item", name = "circuit-orange-loaded", amount = "circuit-blue-loaded" },
+        },
+      },
+    })
+  end
+
+  -----------------------------------------------------------------------------
   -- BOB REVAMP ---------------------------------------------------------------
   -----------------------------------------------------------------------------
   if mods["bobrevamp"] then

--- a/angelsindustries/prototypes/overrides/components-entity-update.lua
+++ b/angelsindustries/prototypes/overrides/components-entity-update.lua
@@ -29,6 +29,7 @@ require("prototypes.overrides.components-bobs-entity-update.components-bobs-gun-
 require("prototypes.overrides.components-bobs-entity-update.components-bobs-inserters-update")
 require("prototypes.overrides.components-bobs-entity-update.components-bobs-labs-update")
 require("prototypes.overrides.components-bobs-entity-update.components-bobs-power-update")
+require("prototypes.overrides.components-bobs-entity-update.components-bobs-radar-update")
 require("prototypes.overrides.components-bobs-entity-update.components-bobs-robots-update")
 require("prototypes.overrides.components-bobs-entity-update.components-bobs-trains-update")
 require("prototypes.overrides.components-bobs-entity-update.components-bobs-turret-update")

--- a/angelsindustries/prototypes/overrides/global-tech-base-cores.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-base-cores.lua
@@ -22,7 +22,6 @@ if angelsmods.industries.tech then
   AI.core_replace("turrets", "war", "basic")
   AI.core_replace("flammables", "war", "enhance")
   -- REFINING
-  AI.core_replace("water-treatment", "processing", "basic")
   -- SMELTING
   AI.core_replace("angels-solder-smelting-basic", "processing", "basic")
   -- BIO PROCESSING

--- a/angelsindustries/prototypes/overrides/global-tech-base-packs.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-base-packs.lua
@@ -15,7 +15,6 @@ if angelsmods.industries.tech then
     "logistics",
     "turrets",
     -- REFINING
-    "water-treatment",
     -- SMELTING
     "angels-solder-smelting-basic",
     -- BIO PROCESSING
@@ -113,11 +112,13 @@ if angelsmods.industries.tech then
   AI.pack_replace("automated-construction", "blue", "orange")
   AI.pack_replace("construction-robotics", "blue", "orange")
   AI.pack_replace("electric-energy-distribution-2", "blue", "orange")
+  AI.pack_replace("advanced-material-processing-2", "blue", "orange")
   --REFINING
   AI.pack_replace("ore-leaching", "blue", "orange")
   OV.remove_prereq("ore-leaching", "tech-blue-packs")
   AI.pack_replace("geode-processing-2", "green", "orange")
   AI.pack_replace("advanced-ore-refining-2", "blue", "orange")
+  AI.pack_replace("water-treatment-3", "blue", "orange")
   --SMELTING
   AI.pack_replace("angels-metallurgy-3", "blue", "orange")
   OV.remove_prereq("angels-metallurgy-3", "tech-blue-packs")
@@ -192,8 +193,11 @@ if angelsmods.industries.tech then
   OV.remove_prereq("kovarex-enrichment-process", "production-science-pack")
   -- REFINING
   OV.remove_prereq("ore-refining", "production-science-pack")
+  OV.remove_prereq("water-treatment-4", "production-science-pack")
   -- PETROCHEM
   OV.remove_prereq("water-chemistry-1", "production-science-pack")
+  OV.remove_prereq("angels-advanced-chemistry-4", "production-science-pack")
+  OV.remove_prereq("slag-processing-3", "production-science-pack")
   -- SMELTING
   OV.remove_prereq("angels-metallurgy-4", "production-science-pack")
   OV.remove_science_pack("angels-tungsten-smelting-2", "production-science-pack")

--- a/angelsindustries/prototypes/overrides/global-tech-bobs-cores.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-bobs-cores.lua
@@ -184,10 +184,11 @@ if angelsmods.industries.tech then
   if mods["bobwarfare"] then
     AI.core_replace("bob-robot-gun-1", "logistic", "war")
     --radars
-    AI.core_replace("radars", "basic", "exploration")
+    AI.core_replace("radars-1", "basic", "exploration")
     AI.core_replace("radars-2", "basic", "exploration")
     AI.core_replace("radars-3", "basic", "exploration")
     AI.core_replace("radars-4", "processing", "exploration")
+    AI.core_replace("radars-5", "processing", "exploration")
     --mines
     AI.core_replace("poison-mine", "basic", "war")
     AI.core_replace("slowdown-mine", "basic", "war")

--- a/angelsindustries/prototypes/overrides/global-tech-bobs-cores.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-bobs-cores.lua
@@ -147,8 +147,10 @@ if angelsmods.industries.tech then
   -- BOBS LOGISTICS -------------------------------------------------------------
   -------------------------------------------------------------------------------
   if mods["boblogistics"] then
-    AI.core_replace("logistics-0", "logistic", "basic")
-    AI.core_replace("logistics", "basic", "logistic")
+    if settings.startup["bobmods-logistics-beltoverhaul"].value == true then
+      AI.core_replace("logistics-0", "logistic", "basic")
+      AI.core_replace("logistics", "basic", "logistic")
+    end
     -- toolbelts
     AI.core_replace("toolbelt-2", "basic", "enhance")
     AI.core_replace("toolbelt-3", "processing", "enhance")

--- a/angelsindustries/prototypes/overrides/global-tech-bobs-packs.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-bobs-packs.lua
@@ -201,9 +201,11 @@ if angelsmods.industries.tech then
   -------------------------------------------------------------------------------
   if mods["boblogistics"] then
     --adds bob logistics stuffs
-    -- basic logistics
-    AI.pack_replace("logistics-0", "red", "grey")
-    AI.pack_replace("logistics", "grey", "red")
+    if settings.startup["bobmods-logistics-beltoverhaul"].value == true then
+      -- basic logistics
+      AI.pack_replace("logistics-0", "red", "grey")
+      AI.pack_replace("logistics", "grey", "red")
+    end
     -- toolbelts
     AI.pack_replace("toolbelt-2", "blue", "orange")
     OV.remove_prereq("toolbelt-2", "tech-blue-packs")

--- a/angelsindustries/prototypes/overrides/global-tech-bobs-packs.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-bobs-packs.lua
@@ -288,7 +288,8 @@ if angelsmods.industries.tech then
     AI.pre_req_replace("bob-rocket", "military-3", "angels-components-weapons-advanced")
     AI.pre_req_replace("bob-rocket", "tungsten-processing", "angels-explosives-1")
     --radars
-    AI.pack_replace("radars-4", "blue", "yellow")
+    AI.pack_replace("radars-3", "blue", "orange")
+    OV.remove_prereq("radars-4", "production-science-pack")
     --small fixes
     AI.pack_replace("follower-robot-count-1", "green", "orange")
     AI.pack_replace("follower-robot-count-2", "green", "orange")

--- a/angelsindustries/prototypes/overrides/global-tech-bobs-packs.lua
+++ b/angelsindustries/prototypes/overrides/global-tech-bobs-packs.lua
@@ -15,7 +15,7 @@ if angelsmods.industries.tech then
     AI.pack_replace("polishing", "green", "orange")
     AI.pack_replace("gem-processing-1", "green", "orange")
     AI.pack_replace("gem-processing-2", "green", "orange")
-    --OV.remove_science_pack("lubricant", "angels-science-pack-green")
+    AI.pack_replace("electric-mixing-furnace", "blue", "orange")
 
     if not mods["bobtech"] then --alien resources
       AI.pack_replace("alien-blue-research", "yellow", "blue")
@@ -27,6 +27,7 @@ if angelsmods.industries.tech then
     end
 
     OV.remove_prereq("nitinol-processing", "production-science-pack")
+    OV.remove_prereq("tungsten-alloy-processing", "production-science-pack")
     AI.pack_replace("ceramics", "blue", "orange")
     AI.pack_replace("cobalt-processing", "blue", "orange")
 
@@ -48,6 +49,10 @@ if angelsmods.industries.tech then
     -- assemblers tier 2+
     AI.pack_replace("automation-4", "blue", "orange")
     OV.remove_prereq("automation-4", "tech-blue-packs")
+    if settings.startup["bobmods-assembly-electronicmachines"].value == true then
+      AI.pack_replace("electronics-machine-3", "yellow", "blue")
+      OV.remove_prereq("electronics-machine-3", "production-science-pack")
+    end
     --chemplants
     if settings.startup["bobmods-assembly-chemicalplants"].value == true then
     end
@@ -55,6 +60,10 @@ if angelsmods.industries.tech then
     if settings.startup["bobmods-assembly-oilfurnaces"].value then
     end
     if settings.startup["bobmods-assembly-multipurposefurnaces"].value then
+      OV.remove_prereq("multi-purpose-furnace-1", "production-science-pack")
+    end
+    if settings.startup["bobmods-assembly-furnaces"].value == true then
+      OV.remove_prereq("advanced-material-processing-3", "production-science-pack")
     end
     --electrolysers
     if settings.startup["bobmods-assembly-electrolysers"].value then
@@ -108,6 +117,8 @@ if angelsmods.industries.tech then
       OV.remove_prereq("steel-axe-4", "tech-blue-packs")
     end
     --mining drills
+    AI.pack_replace("bob-drills-2", "green", "orange")
+    AI.pack_replace("bob-drills-4", "blue", "yellow")
     AI.pack_replace("bob-area-drills-2", "green", "orange")
     AI.pack_replace("bob-area-drills-4", "blue", "yellow")
   end
@@ -210,8 +221,8 @@ if angelsmods.industries.tech then
       OV.remove_science_pack("robotics", "angels-science-pack-orange")
       AI.pack_replace("bob-robotics-2", "blue", "orange")
       OV.remove_prereq("bob-robotics-3", "production-science-pack")
-      AI.pack_replace("bob-robotics-4", "blue", "yellow")
-      AI.pack_replace("bob-robots-3", "blue", "yellow")
+      AI.pack_replace("bob-robotics-3", "yellow", "blue")
+      AI.pack_replace("bob-robots-2", "yellow", "blue")
     end
     -- inserter techs
     AI.pack_replace("inserter-capacity-bonus-1", "orange", "green")
@@ -229,11 +240,17 @@ if angelsmods.industries.tech then
     -- belt techs
     AI.pack_replace("logistics-3", "blue", "orange")
     OV.remove_prereq("logistics-3", "tech-blue-packs")
+    OV.remove_prereq("logistics-4", "production-science-pack")
     -- railway
     AI.pack_replace("bob-railway-2", "green", "orange")
     AI.pack_replace("bob-armoured-railway-2", "blue", "yellow")
     AI.pack_replace("bob-fluid-wagon-2", "green", "orange")
     AI.pack_replace("bob-armoured-fluid-wagon-2", "blue", "yellow")
+    -- repair packs techs
+    AI.pack_replace("bob-repair-pack-5", "blue", "yellow")
+    -- fluid handling techs
+    AI.pack_replace("bob-fluid-handling-2", "green", "orange")
+    AI.pack_replace("bob-fluid-handling-4", "blue", "yellow")
   end
 
   -------------------------------------------------------------------------------
@@ -265,8 +282,10 @@ if angelsmods.industries.tech then
     AI.pack_replace("bob-laser-turrets-3", "blue", "orange")
     OV.remove_prereq("bob-laser-turrets-3", "military-3")
     OV.add_prereq("bob-laser-turrets-4", "military-3")
+    OV.remove_prereq("bob-laser-turrets-4", "production-science-pack")
     AI.pack_replace("bob-plasma-turrets-1", "green", "orange")
     AI.pack_replace("bob-plasma-turrets-2", "green", "orange")
+    OV.remove_prereq("bob-plasma-turrets-4", "production-science-pack")
     if mods["angelsexploration"] then
       AI.pack_replace("angels-rocket-turret", "green", "orange")
     end
@@ -294,6 +313,7 @@ if angelsmods.industries.tech then
     AI.pack_replace("follower-robot-count-1", "green", "orange")
     AI.pack_replace("follower-robot-count-2", "green", "orange")
     OV.remove_prereq("nitroglycerin-processing", "chlorine-processing-2") -- no clue why it works nowhere else...
+    OV.remove_prereq("walking-vehicle", "production-science-pack")
   end
 
   -------------------------------------------------------------------------------
@@ -312,6 +332,11 @@ if angelsmods.industries.tech then
     AI.pack_replace("vehicle-fusion-reactor-equipment-3", "yellow", "blue")
     AI.pack_replace("vehicle-big-turret-equipment-3", "yellow", "blue")
     AI.pre_req_replace("vehicle-big-turret-equipment-3", "military-4", "military-3")
+    OV.remove_prereq("vehicle-energy-shield-equipment-3", "production-science-pack")
+    OV.remove_prereq("vehicle-battery-equipment-4", "production-science-pack")
+    OV.remove_prereq("vehicle-battery-equipment-6", "tech-yellow-packs")
+    OV.remove_prereq("vehicle-fusion-reactor-equipment-3", "production-science-pack")
+    OV.remove_prereq("vehicle-laser-defense-equipment-3", "production-science-pack")
   end
 
   -------------------------------------------------------------------------------
@@ -324,6 +349,10 @@ if angelsmods.industries.tech then
     AI.pack_replace("exoskeleton-equipment", "green", "orange")
     AI.pack_replace("solar-panel-equipment-2", "green", "orange")
     AI.pack_replace("solar-panel-equipment-4", "blue", "yellow")
+    OV.remove_prereq("bob-energy-shield-equipment-3", "production-science-pack")
+    OV.remove_prereq("bob-battery-equipment-4", "production-science-pack")
+    OV.remove_prereq("bob-battery-equipment-6", "tech-yellow-packs")
+    OV.remove_prereq("personal-laser-defense-equipment-3", "production-science-pack")
   end
 
   -------------------------------------------------------------------------------
@@ -337,21 +366,31 @@ if angelsmods.industries.tech then
     if settings.startup["bobmods-power-steam"].value == true then
       AI.pack_replace("bob-steam-turbine-1", "blue", "orange")
       AI.pack_replace("bob-steam-turbine-3", "blue", "yellow")
+      OV.remove_prereq("bob-steam-turbine-2", "production-science-pack")
       AI.pack_replace("bob-steam-engine-3", "blue", "orange")
+      OV.remove_prereq("bob-steam-engine-4", "production-science-pack")
       AI.pack_replace("bob-boiler-3", "blue", "orange")
+      OV.remove_prereq("bob-boiler-4", "production-science-pack")
       AI.pack_replace("bob-oil-boiler-2", "blue", "orange")
+      OV.remove_prereq("bob-oil-boiler-3", "production-science-pack")
       AI.pack_replace("bob-heat-exchanger-2", "blue", "orange")
     end
     if settings.startup["bobmods-power-fluidgenerator"].value == true then
       AI.pack_replace("fluid-generator-2", "blue", "orange")
+      OV.remove_prereq("fluid-generator-3", "production-science-pack")
+    end
+    if settings.startup["bobmods-power-heatsources"].value == true then
+      AI.pack_replace("burner-reactor-2", "blue", "orange")
     end
     -- solar power
     if settings.startup["bobmods-power-solar"].value == true then
       AI.pack_replace("bob-solar-energy-2", "blue", "orange")
+      OV.remove_prereq("bob-solar-energy-3", "production-science-pack")
     end
     if settings.startup["bobmods-power-accumulators"].value == true then
       AI.pack_replace("electric-energy-accumulators", "orange", "green")
       AI.pack_replace("bob-electric-energy-accumulators-2", "blue", "orange")
+      OV.remove_prereq("bob-electric-energy-accumulators-3", "production-science-pack")
     end
     -- nuclar power
     if
@@ -360,6 +399,7 @@ if angelsmods.industries.tech then
       or settings.startup["bobmods-power-heatsources"].value == true
     then
       AI.pack_replace("bob-heat-pipe-2", "blue", "orange")
+      OV.remove_prereq("bob-heat-pipe-3", "production-science-pack")
     end
     -- power distribution
     if settings.startup["bobmods-power-poles"].value == true then


### PR DESCRIPTION
Resolves #889 - Radars
Resolves #636 - Splitters

# Tech Tree Cleanup

### Yellow Science
Multiple Blue science analyzer techs have "Yellow science: late-game" as a prerequisite. It should just be the lab techs that depend directly on the yellow science tech.
![image](https://user-images.githubusercontent.com/59639/215415088-891d6e66-e76f-467c-aded-784d629a0e22.png)

### Water Treatment
There is no longer any need for Water Treatment to be a Grey Science tech. Previously it was as Brown Algae (from Saline Water) was unlocked by Basic Algae Processing.

![image](https://user-images.githubusercontent.com/59639/215415636-af139575-bbab-4bdb-9cf9-5ec75df101cc.png)

![image](https://user-images.githubusercontent.com/59639/215415705-ae9ba0f2-9230-480b-ac7d-db309a3bb8ce.png)

### Furnaces
![image](https://user-images.githubusercontent.com/59639/215416175-9d3f15a0-7e69-475f-a9ea-4ed5e9089755.png)
![image](https://user-images.githubusercontent.com/59639/215416272-33f338dd-69a7-457c-ada2-70f03d40e6d4.png)

### Drills
Mining Drills and Large Area Mining Drills techs should be at the same tech tier. (I'm considering combining these techs in Bob's).
![image](https://user-images.githubusercontent.com/59639/215416664-14ea1bb7-c89d-4d2e-8040-7ad3e614dbd6.png)

### Electronics Assembling Machine 3
Electronics Assembling Machine 3 should be same tech tier as Assembling Machine 5
![image](https://user-images.githubusercontent.com/59639/215417438-76c9a07e-5c7b-4dcb-ac56-69bbfcf3ee36.png)

### Robotics
Purple Tier Robots should be unlocked by Blue Analyzers.
![image](https://user-images.githubusercontent.com/59639/215417611-6815c5e9-c297-427e-a38e-2443af83b79f.png)

