### PR TITLE
Default Ingredient Type

### DIFF
--- a/angelsrefining/prototypes/recipe-builder.lua
+++ b/angelsrefining/prototypes/recipe-builder.lua
@@ -84,7 +84,7 @@ local function check_ingredients(ingredients)
       i_name = item[1]
       i_count = item[2]
     else
-      i_type = item.type
+      i_type = item.type or "item"
       i_name = item.name
       i_count = item.amount
     end


### PR DESCRIPTION
Ingredient type is optional. Should default to "item".
https://wiki.factorio.com/Types/IngredientPrototype

Resolves #885