### PR TITLE
Add new unit test - redundant recipe unlocks

### DIFF
--- a/angelsdev-unit-test/unit-tests.lua
+++ b/angelsdev-unit-test/unit-tests.lua
@@ -10,6 +10,7 @@ local unit_tests = {
   require("unit-tests.unit-test-009"),
   require("unit-tests.unit-test-010"),
   require("unit-tests.unit-test-011"),
+  require("unit-tests.unit-test-012"),
 }
 
 local unit_test_functions = require("unit-test-functions")

--- a/angelsdev-unit-test/unit-tests/unit-test-012.lua
+++ b/angelsdev-unit-test/unit-tests/unit-test-012.lua
@@ -1,0 +1,108 @@
+-- This unit test validates that recipes are not unlocked by both a technology and one of it's prerequite technologies
+local unit_test_functions = require("unit-test-functions")
+
+local starting_unlocks = { recipes = {} }
+local processed_techs = {}
+local unit_test_result = unit_test_functions.test_successful
+
+local function process_tech(tech)
+  local result = { name = tech.name, recipes = {} }
+
+  -- Get unlocks from prerequisite techs
+  for prereq_name, _ in pairs(tech.prerequisites) do
+    local prereq = processed_techs[prereq_name]
+    if prereq then
+      for recipe_name, unlocked_by in pairs(prereq.recipes) do
+        result.recipes[recipe_name] = unlocked_by
+      end
+    end
+  end
+
+  if #tech.prerequisites == 0 then
+    for recipe_name, _ in pairs(starting_unlocks.recipes) do
+      result.recipes[recipe_name] = "N/A"
+    end
+  end
+
+  -- Build lists of recipes unlocked by this tech
+  for _, modifier in pairs(tech.effects) do
+    if modifier.type == "unlock-recipe" then
+      local unlocked_by = result.recipes[modifier.recipe]
+      if unlocked_by then
+        unit_test_functions.print_msg(
+          string.format(
+            "Recipe %q is unlocked by Tech %q as well as prerequisite tech %q.",
+            modifier.recipe,
+            tech.name,
+            unlocked_by
+          )
+        )
+        unit_test_result = unit_test_functions.test_failed
+      end
+      result.recipes[modifier.recipe] = unlocked_by or tech.name
+    end
+  end
+
+  return result
+end
+
+local function make_starting_unlocks()
+  local starting_tech = { name = "starting", prerequisites = {}, effects = {} }
+
+  local recipe_filters = {}
+  table.insert(recipe_filters, { filter = "hidden", invert = true, mode = "and" })
+  table.insert(recipe_filters, { filter = "enabled", invert = false, mode = "and" })
+  local recipe_prototypes = game.get_filtered_recipe_prototypes(recipe_filters)
+
+  for _, recipe in pairs(recipe_prototypes) do
+    table.insert(starting_tech.effects, { type = "unlock-recipe", recipe = recipe.name })
+  end
+
+  starting_unlocks = process_tech(starting_tech)
+end
+
+local unit_test_012 = function()
+
+  -- Build lists recipes unlocked at the start of the game
+  make_starting_unlocks()
+
+  -- Build list of technologies with recipes
+
+  local tech_filters = {}
+  table.insert(tech_filters, { filter = "hidden", invert = true, mode = "and" })
+  table.insert(tech_filters, { filter = "enabled", invert = false, mode = "and" })
+  local tech_prototypes = game.get_filtered_technology_prototypes(tech_filters)
+
+  local I = 0
+  local escape = false
+
+  while (#tech_prototypes > I) and (escape == false) do
+    escape = true
+    for tech_name, tech in pairs(tech_prototypes) do
+      if not processed_techs[tech_name] then
+        local all_prereqs_processed = true
+        for prereq_name, prereq in pairs(tech.prerequisites) do
+          if not processed_techs[prereq_name] then
+            all_prereqs_processed = false
+            break
+          end
+        end
+
+        if all_prereqs_processed then
+          processed_techs[tech_name] = process_tech(tech)
+          I = I + 1
+          escape = false
+        end
+      end
+    end
+  end
+
+  if escape == true then
+    unit_test_functions.print_msg("Not all techs were checked. Possibly due to hidden prerequisites")
+    unit_test_result = unit_test_functions.test_failed
+  end
+
+  return unit_test_result
+end
+
+return unit_test_012

--- a/angelspetrochem/prototypes/global-override/bobrevamp.lua
+++ b/angelspetrochem/prototypes/global-override/bobrevamp.lua
@@ -22,9 +22,7 @@ if mods["bobrevamp"] then
 
   OV.add_unlock("flammables", "solid-fuel-fuel-oil")
   OV.add_unlock("flammables", "solid-fuel-naphtha")
-  OV.add_unlock("angels-advanced-gas-processing", "solid-fuel-methane")
 
-  OV.add_prereq("angels-advanced-gas-processing", "flammables")
   OV.add_prereq("gas-synthesis", "flammables")
   OV.add_prereq("angels-nitrogen-processing-3", "flammables")
 

--- a/angelspetrochem/prototypes/global-override/bobrevamp.lua
+++ b/angelspetrochem/prototypes/global-override/bobrevamp.lua
@@ -16,25 +16,9 @@ if mods["bobrevamp"] then
 
   OV.disable_technology({ "solid-fuel" })
 
-  OV.remove_unlock("angels-oil-processing", "solid-fuel-fuel-oil")
-  OV.remove_unlock("angels-oil-processing", "solid-fuel-naphtha")
-  OV.remove_unlock("gas-processing", "solid-fuel-methane")
-
-  OV.add_unlock("flammables", "solid-fuel-fuel-oil")
-  OV.add_unlock("flammables", "solid-fuel-naphtha")
-
-  OV.add_prereq("gas-synthesis", "flammables")
-  OV.add_prereq("angels-nitrogen-processing-3", "flammables")
-
-  if mods["bobplates"] then
-    OV.remove_unlock("angels-oil-processing", "liquid-fuel")
-    OV.remove_unlock("angels-oil-processing", "solid-fuel-from-hydrogen")
-
-    --OV.add_unlock("flammables", "solid-fuel-from-hydrogen")
-
-    if mods["bobwarfare"] then
-      OV.add_prereq("military-3", "flammables")
-    end
+  if mods["bobplates"] and mods["bobwarfare"] then
+    -- Napalm capsules require Liquid fuel
+    OV.add_prereq("military-3", "flammables")
   end
 
   -----------------------------------------------------------------------------

--- a/angelspetrochem/prototypes/override/angelspetrochem.lua
+++ b/angelspetrochem/prototypes/override/angelspetrochem.lua
@@ -19,7 +19,15 @@ if mods["bobplates"] and data.raw["fluid"]["deuterium"] then
   OV.disable_technology("deuterium-processing")
   OV.add_prereq("water-chemistry-2", "nuclear-fuel-reprocessing")
 
-  OV.add_unlock("water-chemistry-2", "deuterium-fuel-cell")
+  if
+    mods["bobrevamp"]
+    and mods["bobpower"]
+    and settings.startup["bobmods-revamp-nuclear"].value == true
+  then
+    -- deuterium-fuel-cell will be unlocked by bob-nuclear-power-3
+  else
+    OV.add_unlock("water-chemistry-2", "deuterium-fuel-cell")
+  end
   OV.set_science_pack("deuterium-fuel-reprocessing", "utility-science-pack", 1)
   OV.set_science_pack("deuterium-fuel-cell-2", "utility-science-pack", 1)
 elseif angelsmods.industries and angelsmods.industries.overhaul then

--- a/angelspetrochem/prototypes/override/base-game.lua
+++ b/angelspetrochem/prototypes/override/base-game.lua
@@ -81,11 +81,8 @@ end
 move_item("steam", "petrochem-basic-fluids", "a", "fluid")
 move_item("solid-fuel", "petrochem-fuel", "a[solid-fuel]-a")
 
-OV.remove_unlock("angels-oil-processing", "solid-fuel-naphtha")
 OV.add_unlock("flammables", "solid-fuel-naphtha")
-OV.remove_unlock("angels-oil-processing", "solid-fuel-fuel-oil")
 OV.add_unlock("flammables", "solid-fuel-fuel-oil")
-OV.remove_unlock("gas-processing", "solid-fuel-methane")
 OV.add_unlock("flammables", "solid-fuel-methane")
 OV.add_prereq("flammables", "gas-processing")
 

--- a/angelspetrochem/prototypes/technology/petrochem-basic-chemistry.lua
+++ b/angelspetrochem/prototypes/technology/petrochem-basic-chemistry.lua
@@ -552,6 +552,7 @@ data:extend({
       "angels-nitrogen-processing-2",
       "angels-advanced-chemistry-3",
       "sodium-processing",
+      "flammables",
     },
     effects = {
       {

--- a/angelspetrochem/prototypes/technology/petrochem-petro-chemistry.lua
+++ b/angelspetrochem/prototypes/technology/petrochem-petro-chemistry.lua
@@ -478,6 +478,7 @@ data:extend({
     icons = angelsmods.functions.create_gas_tech_icon({ { 210, 120, 210 }, { 175, 100, 175 }, { 140, 080, 140 } }),
     prerequisites = {
       "angels-advanced-chemistry-3",
+      "flammables",
     },
     effects = {
       {

--- a/angelspetrochem/prototypes/technology/petrochem-petro-chemistry.lua
+++ b/angelspetrochem/prototypes/technology/petrochem-petro-chemistry.lua
@@ -64,14 +64,6 @@ data:extend({
         type = "unlock-recipe",
         recipe = "condensates-oil-refining",
       },
-      {
-        type = "unlock-recipe",
-        recipe = "solid-fuel-naphtha",
-      },
-      {
-        type = "unlock-recipe",
-        recipe = "solid-fuel-fuel-oil",
-      },
     },
     unit = {
       count = 50,
@@ -138,10 +130,6 @@ data:extend({
       {
         type = "unlock-recipe",
         recipe = "gas-fractioning",
-      },
-      {
-        type = "unlock-recipe",
-        recipe = "solid-fuel-methane",
       },
     },
     unit = {


### PR DESCRIPTION
New unit test. Checks for recipes unlocked by a tech as well as one of it's prerequisite techs.

Unit test failures:

- Recipe "solid-fuel-methane" is unlocked by Tech "angels-advanced-gas-processing" as well as prerequisite tech "flammables".
- Recipe "deuterium-fuel-cell" is unlocked by Tech "bob-nuclear-power-3" as well as prerequisite tech "water-chemistry-2".

![image](https://github.com/Arch666Angel/mods/assets/59639/55e4cdb0-9ce8-44ae-a25d-7354df96035e)

![image](https://github.com/Arch666Angel/mods/assets/59639/92487274-3f10-415c-8928-ee2c1356ddeb)
