### PR TITLE
Fixing radar prerequisites

### DIFF
--- a/angelsindustries/prototypes/overrides/components-bobs-entity-update/components-bobs-radar-update.lua
+++ b/angelsindustries/prototypes/overrides/components-bobs-entity-update/components-bobs-radar-update.lua
@@ -56,12 +56,19 @@ if angelsmods.industries.components then
       },
     })
 
-    OV.add_prereq("radars-1", "angels-basic-blocks-1")
-    OV.add_prereq("radars-2", "angels-basic-blocks-2")
-    OV.add_prereq("radars-3", "angels-components-weapons-advanced")
-    OV.add_prereq("radars-4", "military-3")
-    OV.add_prereq("radars-4", "angels-advanced-blocks-1")
-    OV.add_prereq("radars-5", "angels-advanced-blocks-2")
+    if angelsmods.industries.tech then
+      OV.add_prereq("radars-2", "tech-specialised-labs-basic-enhance-2")
+      OV.add_prereq("radars-3", "tech-specialised-labs-basic-enhance-3")
+      OV.add_prereq("radars-4", "tech-specialised-labs-advanced-enhance-1")
+      OV.add_prereq("radars-5", "tech-specialised-labs-advanced-enhance-2")
+    else
+      OV.add_prereq("radars-1", "angels-basic-blocks-1")
+      OV.add_prereq("radars-2", "angels-basic-blocks-2")
+      OV.add_prereq("radars-3", "angels-components-weapons-advanced")
+      OV.add_prereq("radars-4", "military-3")
+      OV.add_prereq("radars-4", "angels-advanced-blocks-1")
+      OV.add_prereq("radars-5", "angels-advanced-blocks-2")
+    end
 
     OV.remove_prereq("radars-2", "electronics")
     OV.remove_prereq("radars-3", "military-3")


### PR DESCRIPTION
Noticed errors in the log file:

>  3.883 Script @boblibrary/technology-functions.lua:873: radars-1 has an invalid prerequisite.
>  3.883 Script @boblibrary/error-functions.lua:19: Prerequisite technology angels-basic-blocks-1 does not exist.
>  3.883 Script @boblibrary/technology-functions.lua:873: radars-2 has an invalid prerequisite.
>  3.883 Script @boblibrary/error-functions.lua:19: Prerequisite technology angels-basic-blocks-2 does not exist.
>  3.883 Script @boblibrary/technology-functions.lua:873: radars-4 has an invalid prerequisite.
>  3.884 Script @boblibrary/error-functions.lua:19: Prerequisite technology angels-advanced-blocks-1 does not exist.
>  3.884 Script @boblibrary/technology-functions.lua:873: radars-5 has an invalid prerequisite.
>  3.884 Script @boblibrary/error-functions.lua:19: Prerequisite technology angels-advanced-blocks-2 does not exist.

These prerequisite techs only exist if tech overhaul is not enabled. This check is being done correctly for Assembling Machines.
https://github.com/Arch666Angel/mods/blob/master/angelsindustries/prototypes/overrides/components-bobs-entity-update/components-bobs-assemblers-update.lua#L74-L89