### PR TITLE
Limit buffer for gardens

### DIFF
--- a/angelsbioprocessing/changelog.txt
+++ b/angelsbioprocessing/changelog.txt
@@ -4,6 +4,7 @@ Date: xx.xx.xxxx
   Changes:
     - Added support for alien artifacts outside of bob enemies
     - Compatibility with Bob's changes (911)
+    - Limited recipes which consume gardens to only buffer 1 craft of ingredients (918)
 ---------------------------------------------------------------------------------------------------
 Version: 0.7.24
 Date: 23.02.2023

--- a/angelsbioprocessing/changelog.txt
+++ b/angelsbioprocessing/changelog.txt
@@ -4,7 +4,7 @@ Date: xx.xx.xxxx
   Changes:
     - Added support for alien artifacts outside of bob enemies
     - Compatibility with Bob's changes (911)
-    - Limited recipes which consume gardens to only buffer 1 craft of ingredients (918)
+    - Recipes that consume Gardens will now only buffer enough ingredients for 1 craft (918)
 ---------------------------------------------------------------------------------------------------
 Version: 0.7.24
 Date: 23.02.2023

--- a/angelsbioprocessing/prototypes/recipes/crop-farming-gardens.lua
+++ b/angelsbioprocessing/prototypes/recipes/crop-farming-gardens.lua
@@ -10,6 +10,7 @@ data:extend({
     subgroup = "farming-temperate-seed",
     enabled = false,
     energy_required = 300,
+    overload_multiplier = 1,
     ingredients = {
       { type = "item", name = "temperate-garden", amount = 1 },
     },
@@ -39,6 +40,7 @@ data:extend({
     subgroup = "farming-temperate-seed",
     enabled = false,
     energy_required = 60,
+    overload_multiplier = 1,
     ingredients = {
       { type = "item", name = "temperate-garden", amount = 1, catalyst_amount = 1 },
       { type = "item", name = "solid-alienated-fertilizer", amount = 2 },
@@ -63,6 +65,7 @@ data:extend({
     subgroup = "farming-temperate-seed",
     enabled = false,
     energy_required = 300,
+    overload_multiplier = 1,
     ingredients = {
       { type = "item", name = "temperate-garden", amount = 1 },
     },
@@ -120,6 +123,7 @@ data:extend({
     subgroup = "farming-temperate-seed",
     enabled = false,
     energy_required = 300,
+    overload_multiplier = 1,
     ingredients = {
       { type = "item", name = "temperate-garden", amount = 1 },
     },
@@ -172,6 +176,7 @@ data:extend({
     subgroup = "farming-desert-seed",
     enabled = false,
     energy_required = 300,
+    overload_multiplier = 1,
     ingredients = {
       { type = "item", name = "desert-garden", amount = 1 },
     },
@@ -201,6 +206,7 @@ data:extend({
     subgroup = "farming-desert-seed",
     enabled = false,
     energy_required = 60,
+    overload_multiplier = 1,
     ingredients = {
       { type = "item", name = "desert-garden", amount = 1, catalyst_amount = 1 },
       { type = "item", name = "solid-alienated-fertilizer", amount = 2 },
@@ -225,6 +231,7 @@ data:extend({
     subgroup = "farming-desert-seed",
     enabled = false,
     energy_required = 300,
+    overload_multiplier = 1,
     ingredients = {
       { type = "item", name = "desert-garden", amount = 1 },
     },
@@ -282,6 +289,7 @@ data:extend({
     subgroup = "farming-desert-seed",
     enabled = false,
     energy_required = 300,
+    overload_multiplier = 1,
     ingredients = {
       { type = "item", name = "desert-garden", amount = 1 },
     },
@@ -334,6 +342,7 @@ data:extend({
     subgroup = "farming-swamp-seed",
     enabled = false,
     energy_required = 300,
+    overload_multiplier = 1,
     ingredients = {
       { type = "item", name = "swamp-garden", amount = 1 },
     },
@@ -363,6 +372,7 @@ data:extend({
     subgroup = "farming-swamp-seed",
     enabled = false,
     energy_required = 60,
+    overload_multiplier = 1,
     ingredients = {
       { type = "item", name = "swamp-garden", amount = 1, catalyst_amount = 1 },
       { type = "item", name = "solid-alienated-fertilizer", amount = 2 },
@@ -387,6 +397,7 @@ data:extend({
     subgroup = "farming-swamp-seed",
     enabled = false,
     energy_required = 300,
+    overload_multiplier = 1,
     ingredients = {
       { type = "item", name = "swamp-garden", amount = 1 },
     },
@@ -444,6 +455,7 @@ data:extend({
     subgroup = "farming-swamp-seed",
     enabled = false,
     energy_required = 300,
+    overload_multiplier = 1,
     ingredients = {
       { type = "item", name = "swamp-garden", amount = 1 },
     },
@@ -639,6 +651,7 @@ data:extend({
   --  subgroup = "farming-temperate-seed",
   --  enabled = false,
   --  energy_required = 600,
+  --  overload_multiplier = 1,
   --  ingredients =
   --  {
   --    {type = "item", name = "desert-garden", amount = 1},
@@ -662,6 +675,7 @@ data:extend({
   --  subgroup = "bio-processor-swamp",
   --  enabled = false,
   --  energy_required = 600,
+  --  overload_multiplier = 1,
   --  ingredients =
   --  {
   --    {type = "item", name = "swamp-garden", amount = 1},
@@ -685,6 +699,7 @@ data:extend({
   --  subgroup = "farming-temperate",
   --  enabled = false,
   --  energy_required = 600,
+  --  overload_multiplier = 1,
   --  ingredients =
   --  {
   --    {type = "item", name = "temperate-garden", amount = 1},
@@ -708,6 +723,7 @@ data:extend({
   --  subgroup = "bio-processor-swamp",
   --  enabled = false,
   --  energy_required = 600,
+  --  overload_multiplier = 1,
   --  ingredients =
   --  {
   --    {type = "item", name = "desert-garden", amount = 1},
@@ -731,6 +747,7 @@ data:extend({
   --  subgroup = "bio-processor-temperate",
   --  enabled = false,
   --  energy_required = 600,
+  --  overload_multiplier = 1,
   --  ingredients =
   --  {
   --    {type = "item", name = "swamp-garden", amount = 1},
@@ -754,6 +771,7 @@ data:extend({
   --  subgroup = "farming-desert-seed",
   --  enabled = false,
   --  energy_required = 600,
+  --  overload_multiplier = 1,
   --  ingredients =
   --  {
   --    {type = "item", name = "temperate-garden", amount = 4},


### PR DESCRIPTION
Garden duplication starts very slowly. By default, inserters will fill a machine with enough ingredients for at least two crafts. Limiting inserter stack size doesn't affect this. This results in a lot of gardens sitting in machine buffers when they could be being used.

Garden processing recipes range from 1 min to 5 mins.

Set the `overload_multiplier` to 1 for recipes that consume gardens.

https://wiki.factorio.com/Prototype/Recipe#overload_multiplier

https://media.discordapp.net/attachments/782726887188594689/1129213546916499477/image.png?width=873&height=671
![image](https://github.com/Arch666Angel/mods/assets/59639/bdd128fc-19d8-4281-9f43-83726295ca31)
