### PR TITLE
Recipe productivity

### DIFF
--- a/angelsindustries/prototypes/overrides/overhaul-nuclear-power.lua
+++ b/angelsindustries/prototypes/overrides/overhaul-nuclear-power.lua
@@ -187,6 +187,15 @@ if angelsmods.industries.overhaul then
           end
         end
       end
+      if data.raw.recipe["plutonium-nucleosynthesis"] then
+        OV.patch_recipes({
+          {
+            name = "plutonium-nucleosynthesis",
+            subgroup = "angels-power-nuclear-processing",
+            order = "b[AMOX]-d[synthesis]",
+          },
+        })
+      end
     else
       --if not rtg, remove bobingabout process
       OV.remove_unlock("bobingabout-enrichment-process", "bobingabout-enrichment-process")

--- a/angelsindustries/prototypes/overrides/overhaul-nuclear-power.lua
+++ b/angelsindustries/prototypes/overrides/overhaul-nuclear-power.lua
@@ -110,7 +110,6 @@ if angelsmods.industries.overhaul then
   -- Productivity
   -------------------------------------------------------------------------------
   angelsmods.functions.allow_productivity("angels-thorium-processing")
-  angelsmods.functions.allow_productivity("angelsore-crystal-mix6-processing") --thorium ore
   angelsmods.functions.allow_productivity("angels-uranium-fuel-cell")
   angelsmods.functions.allow_productivity("angels-mixed-oxide-cell")
   angelsmods.functions.allow_productivity("angels-thorium-fuel-cell")

--- a/angelsrefining/changelog.txt
+++ b/angelsrefining/changelog.txt
@@ -4,6 +4,7 @@ Date: xx.xx.xxxx
   Changes:
     - Moved Electro-refining to purple science. Replaced Crystal catalyst with Hybrid catalyst in Thorium sorting recipe (909)
     - Compatibility with Bob's changes (911)
+    - Enabled productivity modules for Thorium Ore sorting recipe (929)
 ---------------------------------------------------------------------------------------------------
 Version: 0.12.4
 Date: 23.02.2023

--- a/angelsrefining/prototypes/refining-override.lua
+++ b/angelsrefining/prototypes/refining-override.lua
@@ -497,6 +497,7 @@ angelsmods.functions.allow_productivity("angelsore-crystal-mix2-processing")
 angelsmods.functions.allow_productivity("angelsore-crystal-mix3-processing")
 angelsmods.functions.allow_productivity("angelsore-crystal-mix4-processing")
 angelsmods.functions.allow_productivity("angelsore-crystal-mix5-processing")
+angelsmods.functions.allow_productivity("angelsore-crystal-mix6-processing")
 
 angelsmods.functions.allow_productivity("angelsore-pure-mix1-processing")
 angelsmods.functions.allow_productivity("angelsore-pure-mix2-processing")

--- a/angelssmelting/changelog.txt
+++ b/angelssmelting/changelog.txt
@@ -4,6 +4,7 @@ Date: xx.xx.xxxx
   Changes:
     - Increased the tech and required machine tier of Chrome and Platinum (909)
     - Allow Fibreglass boards to be made in Bob's Electronics assembling machines (921)
+    - Enabled productivity modules for Glass, Glass fiber, and Fibreglass recipes (929)
   Bugfixes:
     - Another attempt at fixed smoke on the blast furnace
 ---------------------------------------------------------------------------------------------------

--- a/angelssmelting/prototypes/override/smelting-override-productivity.lua
+++ b/angelssmelting/prototypes/override/smelting-override-productivity.lua
@@ -41,6 +41,11 @@ angelsmods.functions.allow_productivity("angels-roll-platinum-converting")
 
 angelsmods.functions.allow_productivity("angels-mono-silicon-1")
 angelsmods.functions.allow_productivity("angels-mono-silicon-2")
+angelsmods.functions.allow_productivity("angels-plate-glass-1")
+angelsmods.functions.allow_productivity("angels-plate-glass-2")
+angelsmods.functions.allow_productivity("angels-plate-glass-3")
+angelsmods.functions.allow_productivity("angels-coil-glass-fiber")
+angelsmods.functions.allow_productivity("angels-glass-fiber-board")
 
 angelsmods.functions.allow_productivity("angels-plate-silver")
 angelsmods.functions.allow_productivity("angels-wire-coil-silver-converting")

--- a/angelssmelting/prototypes/recipes/smelting-glass.lua
+++ b/angelssmelting/prototypes/recipes/smelting-glass.lua
@@ -178,11 +178,11 @@ data:extend({
       energy_required = 3,
       ingredients = {
         { type = "fluid", name = "liquid-molten-glass", amount = 40 },
-        { type = "fluid", name = "liquid-molten-lead", amount = 20 },
+        { type = "fluid", name = "liquid-molten-lead", amount = 20, catalyst_amount = 20 },
       },
       results = {
         { type = "item", name = "angels-plate-glass", amount = 4 },
-        { type = "item", name = "solid-lead-oxide", amount = 2 },
+        { type = "item", name = "solid-lead-oxide", amount = 2, catalyst_amount = 2 },
       },
       main_product = "angels-plate-glass",
     },
@@ -191,11 +191,11 @@ data:extend({
       energy_required = 3,
       ingredients = {
         { type = "fluid", name = "liquid-molten-glass", amount = 50 * intermediatemulti },
-        { type = "fluid", name = "liquid-molten-lead", amount = 20 },
+        { type = "fluid", name = "liquid-molten-lead", amount = 20, catalyst_amount = 20 },
       },
       results = {
         { type = "item", name = "angels-plate-glass", amount = 4 },
-        { type = "item", name = "solid-lead-oxide", amount = 2 },
+        { type = "item", name = "solid-lead-oxide", amount = 2, catalyst_amount = 2 },
       },
       main_product = "angels-plate-glass",
     },
@@ -216,12 +216,12 @@ data:extend({
       energy_required = 2,
       ingredients = {
         { type = "fluid", name = "liquid-molten-glass", amount = 40 },
-        { type = "fluid", name = "liquid-molten-tin", amount = 20 },
+        { type = "fluid", name = "liquid-molten-tin", amount = 20, catalyst_amount = 20 },
         { type = "fluid", name = "gas-nitrogen", amount = 20 },
       },
       results = {
         { type = "item", name = "angels-plate-glass", amount = 5 },
-        { type = "item", name = "ingot-tin", amount = 2 },
+        { type = "item", name = "ingot-tin", amount = 2, catalyst_amount = 2 },
       },
       main_product = "angels-plate-glass",
     },
@@ -230,12 +230,12 @@ data:extend({
       energy_required = 2,
       ingredients = {
         { type = "fluid", name = "liquid-molten-glass", amount = 50 * intermediatemulti },
-        { type = "fluid", name = "liquid-molten-tin", amount = 20 },
+        { type = "fluid", name = "liquid-molten-tin", amount = 20, catalyst_amount = 20 },
         { type = "fluid", name = "gas-nitrogen", amount = 20 },
       },
       results = {
         { type = "item", name = "angels-plate-glass", amount = 5 },
-        { type = "item", name = "ingot-tin", amount = 2 },
+        { type = "item", name = "ingot-tin", amount = 2, catalyst_amount = 2 },
       },
       main_product = "angels-plate-glass",
     },


### PR DESCRIPTION
- Thorium sorting can only use productivity is Angel's Industries mod is enabled
- Glass recipes can never use productivity

Allow productivity on these for consistency with other Refining / Smelting recipes.