### PR TITLE
Bob's Mods / Agriculture Modules compatibility

### DIFF
--- a/angelsbioprocessing/changelog.txt
+++ b/angelsbioprocessing/changelog.txt
@@ -11,6 +11,7 @@ Date: xx.xx.xxxx
       - Recipe changes for Tree seed generators, Arboretum, and Composter
       - Tech tree changes
     - Added custom error message for when trying to insert invalid items into butchery, composter, or hatchery (933)
+    - Prevent Bob's mods from enabling Agriculture Modules for non bio recipes (937)
 ---------------------------------------------------------------------------------------------------
 Version: 0.7.24
 Date: 23.02.2023

--- a/angelsbioprocessing/info.json
+++ b/angelsbioprocessing/info.json
@@ -11,6 +11,7 @@
     "angelsrefining >= 0.12.1",
     "angelspetrochem >= 0.9.25",
     "angelssmelting >= 0.6.17",
-    "? bobenemies >= 1.1.5"
+    "? bobenemies >= 1.1.5",
+    "? boblibrary >= 1.2.0"
   ]
 }

--- a/angelsbioprocessing/prototypes/recipes/bio-module.lua
+++ b/angelsbioprocessing/prototypes/recipes/bio-module.lua
@@ -41,3 +41,18 @@ data:extend({
     result = "angels-bio-yield-module-3",
   },
 })
+
+if mods["boblibrary"] then
+  for _, module_name in pairs({
+    "angels-bio-yield-module",
+    "angels-bio-yield-module-2",
+    "angels-bio-yield-module-3",
+    "angels-bio-yield-module-4",
+    "angels-bio-yield-module-5",
+    "angels-bio-yield-module-6",
+    "angels-bio-yield-module-7",
+    "angels-bio-yield-module-8"
+  }) do
+    bobmods.lib.module.exclude_productivity_module(module_name)
+  end
+end


### PR DESCRIPTION
Prevent Bob's mods from enabling Agriculture Modules for non bio recipes.
Resolves #937