### PR TITLE
Fixing duplicate fluid product

### DIFF
--- a/angelsbioprocessing/changelog.txt
+++ b/angelsbioprocessing/changelog.txt
@@ -12,6 +12,8 @@ Date: xx.xx.xxxx
       - Tech tree changes
     - Added custom error message for when trying to insert invalid items into butchery, composter, or hatchery (933)
     - Prevent Bob's mods from enabling Agriculture Modules for non bio recipes (937)
+  Bugfixes:
+    - Fixed Gaseous atmosphere puffing recipe missing product Acid gas (942)
 ---------------------------------------------------------------------------------------------------
 Version: 0.7.24
 Date: 23.02.2023

--- a/angelsbioprocessing/prototypes/recipes/bio-refugium-puffer.lua
+++ b/angelsbioprocessing/prototypes/recipes/bio-refugium-puffer.lua
@@ -214,7 +214,7 @@ data:extend({
       { type = "item", name = "bio-puffer-3", amount = 2 },
       { type = "fluid", name = "liquid-nutrient-pulp", amount = 20 },
       { type = "fluid", name = "gas-puffer-atmosphere", amount = 20 },
-      { type = "fluid", name = "gas-acid", amount = 100 },
+      { type = "fluid", name = "gas-acid", amount = 100, catalyst_amount = 20 },
     },
     results = {
       { type = "item", name = "bio-puffer-2", amount = 1, catalyst_amount = 1 },

--- a/angelsbioprocessing/prototypes/recipes/bio-refugium-puffer.lua
+++ b/angelsbioprocessing/prototypes/recipes/bio-refugium-puffer.lua
@@ -214,7 +214,7 @@ data:extend({
       { type = "item", name = "bio-puffer-3", amount = 2 },
       { type = "fluid", name = "liquid-nutrient-pulp", amount = 20 },
       { type = "fluid", name = "gas-puffer-atmosphere", amount = 20 },
-      { type = "fluid", name = "gas-acid", amount = 100, catalyst_amount = 20 },
+      { type = "fluid", name = "gas-acid", amount = 100 },
     },
     results = {
       { type = "item", name = "bio-puffer-2", amount = 1, catalyst_amount = 1 },

--- a/angelsbioprocessing/prototypes/recipes/bio-refugium-puffer.lua
+++ b/angelsbioprocessing/prototypes/recipes/bio-refugium-puffer.lua
@@ -237,7 +237,7 @@ data:extend({
       },
       {
         type = "fluid",
-        name = "gas-puffer-atmosphere",
+        name = "gas-acid",
         amount = 20,
         catalyst_amount = 20,
         show_details_in_recipe_tooltip = false,


### PR DESCRIPTION
Code for this recipe has acid gas listed twice as a product. The first product is ignored. Change product to Acid Gas, to match other recipes.

![image](https://github.com/Arch666Angel/mods/assets/59639/a26243a7-0114-4816-917d-eb7843b7e8e3)
