### PR TITLE
Recipe builder overrides

### DIFF
--- a/angelsrefining/changelog.txt
+++ b/angelsrefining/changelog.txt
@@ -9,6 +9,7 @@ Date: xx.xx.xxxx
     - Added custom error message for when trying to insert invalid items into a barreling pump (933)
     - Changed Crystal catalyst recipe to require Crystallizer 2 (943)
     - Removed Crystal catalyst from Bob's gem ore crystallization recipes (943)
+    - Changed the Recipe Builder to make it easier for other mods to add their own materials (950)
 ---------------------------------------------------------------------------------------------------
 Version: 0.12.4
 Date: 23.02.2023

--- a/angelsrefining/prototypes/recipe-builder.lua
+++ b/angelsrefining/prototypes/recipe-builder.lua
@@ -34,7 +34,9 @@ end
 RB.set_fallback = function(i_type, i_name, fb_list, i_condition) -- i_type either "item" or "fluid", i_name the name of the item, fb_list a table containing subtables { name, multiplier, condition } where item_name is a string, multiplier is a positive number (defaults to 1), and condition is a function taking i_type and i_name as arguments and returning a boolean (defaults to return true) can also be formatted { name = name, multiplier = multiplier, condition = condition }, condition (optional) is like the condition field in a subtable of fb_list but for i_name
   local parent = fallbacks[i_type]
   if parent then
-    if check_raw_for(i_type, i_name) and (not i_condition or i_condition(i_type, i_name)) then
+    if parent[i_name] ~= nil then
+      -- fallback already exists
+    elseif check_raw_for(i_type, i_name) and (not i_condition or i_condition(i_type, i_name)) then
       parent[i_name] = nil
     else
       local sentinel = true


### PR DESCRIPTION
### Story Time!
Someone reported that Extended Angel's was not compatible with Sea Block. Turns out it was fine and they were confused. However this got me started down a rabbit hole, preparing a PR to fix a bunch of minor issues with building unlocks, prerequisites etc.

Extended Angel's uses Angel's Recipe Builder. This works really well for most things. The mod also adds a new type of brick (Titanium Reinforced) that it then tries to set the Recipe Builder to use. The buildings from Extended Angel's will use it but none of the regular Angel's buildings will.

### The Issue
Angel's recipe builder fallbacks are set up in Angel's Refining mod, data-updates stage. The recipes are also built in this stage. This means that there's no opportunity for another mod to get and add additional materials.

To put it another way: Both Angel's and Extended Angel's define fallbacks for `"t6-brick"`. Extended Angel's could define it first, in `data` stage. However Angel's would then overwrite it. If Extended Angel's defines it in `data-updates` stage, Angel's recipes have already been built.

### Possible Solution 1
**Last in wins**
Created the fallbacks in Angel's Refining, `data` stage. The issue with this is that it's trying to check triggers which don't exist at that point as they are created in other mods (mainly Smelting).

This approach could work if the basic fallbacks were set up in Refining then the other mods added their own.

This would allow Extended Angel's to add it's brick in data stage, ready to be used to build Angel's machine recipes.

### Possible Solution 2
**First in wins**
Change the function that adds the fallbacks. Only add it if it doesn't already exist. This sounds like significantly less work but not as flexible a solution.
