### PR TITLE
[BUG] "basic-automation doesn't exist" load error with Angel's Bioprocessing, Bob's Assembling machines, and AAI Industry

### DIFF
--- a/angelsbioprocessing/prototypes/overrides/bio-processing-override-bob.lua
+++ b/angelsbioprocessing/prototypes/overrides/bio-processing-override-bob.lua
@@ -58,7 +58,7 @@ if bobmods then
   })
 end
 
-if mods["bobassembly"] and settings.startup["bobmods-assembly-burner"].value == true then
+if data.raw.technology["basic-automation"] then -- From Bob's Assembling machines, depending on settings
   OV.remove_prereq("bio-processing-brown", "automation")
   OV.add_prereq("bio-processing-brown", "basic-automation")
   OV.remove_prereq("basic-chemistry", "automation")


### PR DESCRIPTION
Angel's bioprocessing adds prerequisites to "basic-automation" if Bob's assembling machines is installed.

But Bob's assembling machines does not actually create "basic-automation" is AAI Industry is installed:
https://github.com/modded-factorio/bobsmods/blob/492bd544746b867b377795f5c6a8d2b8b0bc6a52/bobassembly/prototypes/assembly-burner.lua#L1

This PR fixes the condition in Angel's bioprocessing.