### PR TITLE
Rebalance phenolic board recipe

### DIFF
--- a/angelsbioprocessing/prototypes/overrides/bio-processing-override-bob.lua
+++ b/angelsbioprocessing/prototypes/overrides/bio-processing-override-bob.lua
@@ -81,7 +81,7 @@ if mods["bobelectronics"] then
       ingredients = {
         { "!!" },
         { type = "fluid", name = "liquid-resin", amount = 10 },
-        { type = "item", name = "solid-paper", amount = 10 },
+        { type = "item", name = "solid-paper", amount = 4 },
       },
       category = "electronics-with-fluid",
     },


### PR DESCRIPTION
Uses 4 paper instead of 10 papers for 2 phenolic boards, it feels much more balanced for earlier recipes.