### PR TITLE
Ore sorting facility 5

### DIFF
--- a/angelspetrochem/prototypes/override/angelspetrochem.lua
+++ b/angelspetrochem/prototypes/override/angelspetrochem.lua
@@ -311,10 +311,6 @@ OV.disable_recipe({
 -- SULFURIC ACID ------------------------------------------------------------
 -----------------------------------------------------------------------------
 if angelsmods.trigger.early_sulfuric_acid == true then
-  -- Replace base game sulfur tech early
-  -- Else bob's library technology prerequisite cleanup will cause issues
-  OV.global_replace_technology("sulfur-processing", "angels-sulfur-processing-1")
-
   -- Sulfur 1
   OV.set_science_pack("angels-sulfur-processing-1", "logistic-science-pack", 0)
 

--- a/angelspetrochem/prototypes/override/angelsrefining.lua
+++ b/angelspetrochem/prototypes/override/angelsrefining.lua
@@ -55,6 +55,8 @@ if angelsmods.refining then
   OV.remove_prereq("ore-floatation", "automation-2")
   OV.remove_prereq("ore-floatation", "water-treatment")
   OV.add_prereq("ore-floatation", "basic-chemistry-3")
+  OV.remove_prereq("water-treatment-2", "slag-processing-1")
+  OV.add_prereq("water-treatment-2", "angels-coal-processing-2")
 end
 
 -------------------------------------------------------------------------------

--- a/angelspetrochem/prototypes/override/base-game.lua
+++ b/angelspetrochem/prototypes/override/base-game.lua
@@ -69,6 +69,7 @@ if angelsmods.trigger.early_sulfuric_acid == true then
   OV.remove_prereq("battery", "sulfur-processing")
   OV.add_prereq("battery", "angels-sulfur-processing-2")
 end
+OV.remove_prereq("sulfur-processing", "oil-processing")
 
 move_item("explosives", "petrochem-solids", "b[petrochem-solids-2]-a[explosives]")
 if angelsmods.trigger.early_sulfuric_acid == true then

--- a/angelspetrochem/prototypes/technology/petrochem-basic-chemistry.lua
+++ b/angelspetrochem/prototypes/technology/petrochem-basic-chemistry.lua
@@ -248,8 +248,7 @@ data:extend({
     icons = angelsmods.functions.create_gas_tech_icon({ { 067, 067, 067 }, { 056, 056, 056 }, { 045, 045, 045 } }),
     prerequisites = {
       "angels-coal-processing",
-      --"basic-chemistry-3",
-      "water-treatment-2",
+      "basic-chemistry-3",
     },
     effects = {
       {

--- a/angelsrefining/changelog.txt
+++ b/angelsrefining/changelog.txt
@@ -3,6 +3,8 @@ Version: 0.12.8
 Date: ???
   Bugfixes:
     - Fixed when placing an electric offshore waterpump over its ghost, the module request would be forgotten (973)
+  Changes:
+    - Added Ore Sorting Facility 5. Catalyst sorting requires a higher tier ore sorting facility (979)
 ---------------------------------------------------------------------------------------------------
 Version: 0.12.7
 Date: 21.02.2024

--- a/angelsrefining/locale/en/ore-refining.cfg
+++ b/angelsrefining/locale/en/ore-refining.cfg
@@ -31,6 +31,7 @@ ore-sorting-facility=Ore sorting facility 1
 ore-sorting-facility-2=Ore sorting facility 2
 ore-sorting-facility-3=Ore sorting facility 3
 ore-sorting-facility-4=Ore sorting facility 4
+ore-sorting-facility-5=Ore sorting facility 5
 
 liquifier=Liquefier 1
 liquifier-2=Liquefier 2

--- a/angelsrefining/prototypes/buildings/ore-sorting-facility.lua
+++ b/angelsrefining/prototypes/buildings/ore-sorting-facility.lua
@@ -38,7 +38,7 @@ data:extend({
     },
     allowed_effects = { "consumption", "speed", "pollution", "productivity" },
     crafting_categories = { "ore-sorting" },
-    crafting_speed = 0.75,
+    crafting_speed = 0.5,
     energy_source = {
       type = "electric",
       usage_priority = "secondary-input",
@@ -143,7 +143,7 @@ data:extend({
     },
     allowed_effects = { "consumption", "speed", "pollution", "productivity" },
     crafting_categories = { "ore-sorting", "ore-sorting-2" },
-    crafting_speed = 1,
+    crafting_speed = 0.75,
     energy_source = {
       type = "electric",
       usage_priority = "secondary-input",
@@ -248,7 +248,7 @@ data:extend({
     },
     allowed_effects = { "consumption", "speed", "pollution", "productivity" },
     crafting_categories = { "ore-sorting", "ore-sorting-2", "ore-sorting-3" },
-    crafting_speed = 1.5,
+    crafting_speed = 1,
     energy_source = {
       type = "electric",
       usage_priority = "secondary-input",
@@ -342,6 +342,7 @@ data:extend({
     flags = { "placeable-neutral", "player-creation" },
     minable = { mining_time = 1, result = "ore-sorting-facility-4" },
     fast_replaceable_group = "ore-sorting-facility",
+    next_upgrade = "ore-sorting-facility-5",
     max_health = 300,
     corpse = "big-remnants",
     dying_explosion = "medium-explosion",
@@ -352,7 +353,7 @@ data:extend({
     },
     allowed_effects = { "consumption", "speed", "pollution", "productivity" },
     crafting_categories = { "ore-sorting", "ore-sorting-2", "ore-sorting-3", "ore-sorting-4" },
-    crafting_speed = 2,
+    crafting_speed = 1.5,
     energy_source = {
       type = "electric",
       usage_priority = "secondary-input",
@@ -360,6 +361,109 @@ data:extend({
     },
     energy_usage = "300kW",
     --ingredient_count = 6,
+    animation = {
+      layers = {
+        {
+          filename = "__angelsrefining__/graphics/entity/ore-sorting-facility/ore-sorting-facility-base.png",
+          priority = "extra-high",
+          width = 224,
+          height = 230,
+          frame_count = 40,
+          line_length = 10,
+          shift = util.by_pixel(0, -2),
+          animation_speed = 0.5,
+          hr_version = angelsmods.trigger.enable_hq_graphics
+              and {
+                filename = "__angelsrefining__/graphics/entity/ore-sorting-facility/hr-ore-sorting-facility-base.png",
+                priority = "extra-high",
+                width = 449,
+                height = 458,
+                frame_count = 40,
+                line_length = 10,
+                shift = util.by_pixel(0, -2.5),
+                animation_speed = 0.5,
+                scale = 0.5,
+              }
+            or nil,
+        },
+        {
+          filename = "__angelsrefining__/graphics/entity/ore-sorting-facility/ore-sorting-facility-shadow.png",
+          priority = "extra-high",
+          width = 265,
+          height = 179,
+          repeat_count = 40,
+          shift = util.by_pixel(21, 25),
+          animation_speed = 0.5,
+          draw_as_shadow = true,
+          hr_version = angelsmods.trigger.enable_hq_graphics
+              and {
+                filename = "__angelsrefining__/graphics/entity/ore-sorting-facility/hr-ore-sorting-facility-shadow.png",
+                priority = "extra-high",
+                width = 528,
+                height = 356,
+                repeat_count = 40,
+                shift = util.by_pixel(21.5, 24.5),
+                animation_speed = 0.5,
+                draw_as_shadow = true,
+                scale = 0.5,
+              }
+            or nil,
+        },
+      },
+    },
+    vehicle_impact_sound = { filename = "__base__/sound/car-metal-impact.ogg", volume = 0.65 },
+    working_sound = {
+      sound = { filename = "__angelsrefining__/sound/ore-sorting-facility.ogg", volume = 0.5 },
+      idle_sound = { filename = "__base__/sound/idle1.ogg", volume = 0.6 },
+      audible_distance_modifier = 0.5,
+      apparent_volume = 2.5,
+    },
+  },
+  {
+    type = "item",
+    name = "ore-sorting-facility-5",
+    icons = angelsmods.functions.add_number_icon_layer({
+      {
+        icon = "__angelsrefining__/graphics/icons/ore-sorting-facility.png",
+        icon_size = 64,
+        icon_mipmaps = 4,
+      },
+    }, 5, angelsmods.refining.number_tint),
+    subgroup = "ore-sorter",
+    order = "e[ore-sorting-facility-5]",
+    place_result = "ore-sorting-facility-5",
+    stack_size = 10,
+  },
+  {
+    type = "assembling-machine",
+    name = "ore-sorting-facility-5",
+    icons = angelsmods.functions.add_number_icon_layer({
+      {
+        icon = "__angelsrefining__/graphics/icons/ore-sorting-facility.png",
+        icon_size = 64,
+        icon_mipmaps = 4,
+      },
+    }, 5, angelsmods.refining.number_tint),
+    flags = { "placeable-neutral", "player-creation" },
+    minable = { mining_time = 1, result = "ore-sorting-facility-5" },
+    fast_replaceable_group = "ore-sorting-facility",
+    max_health = 300,
+    corpse = "big-remnants",
+    dying_explosion = "medium-explosion",
+    collision_box = { { -3.4, -3.4 }, { 3.4, 3.4 } },
+    selection_box = { { -3.5, -3.5 }, { 3.5, 3.5 } },
+    module_specification = {
+      module_slots = 3,
+    },
+    allowed_effects = { "consumption", "speed", "pollution", "productivity" },
+    crafting_categories = { "ore-sorting", "ore-sorting-2", "ore-sorting-3", "ore-sorting-4", "ore-sorting-5" },
+    crafting_speed = 2,
+    energy_source = {
+      type = "electric",
+      usage_priority = "secondary-input",
+      emissions_per_minute = 0.07 * 60,
+    },
+    energy_usage = "350kW",
     animation = {
       layers = {
         {

--- a/angelsrefining/prototypes/recipe-builder-fallbacks.lua
+++ b/angelsrefining/prototypes/recipe-builder-fallbacks.lua
@@ -221,6 +221,7 @@ angelsmods.functions.RB.set_fallback("item", "sorter-1", { { "block-production-1
 angelsmods.functions.RB.set_fallback("item", "sorter-2", { { "block-production-2", 5 }, { "ore-sorting-facility" } })
 angelsmods.functions.RB.set_fallback("item", "sorter-3", { { "block-mprocessing-3", 5 }, { "ore-sorting-facility-2" } })
 angelsmods.functions.RB.set_fallback("item", "sorter-4", { { "block-mprocessing-4", 5 }, { "ore-sorting-facility-3" } })
+angelsmods.functions.RB.set_fallback("item", "sorter-5", { { "block-mprocessing-5", 5 }, { "ore-sorting-facility-4" } })
 
 angelsmods.functions.RB.set_fallback("item", "filter-1", { { "block-production-2", 3 } })
 angelsmods.functions.RB.set_fallback("item", "filter-2", { { "block-production-3", 3 }, { "filtration-unit" } })

--- a/angelsrefining/prototypes/recipes/refining-dynamic/chunk-processing.lua
+++ b/angelsrefining/prototypes/recipes/refining-dynamic/chunk-processing.lua
@@ -5,7 +5,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore1-chunk-processing",
-    category = "ore-sorting",
+    category = "ore-sorting-2",
     subgroup = "ore-sorting-t2",
     energy_required = 1.5,
     enabled = false,
@@ -32,7 +32,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore2-chunk-processing",
-    category = "ore-sorting",
+    category = "ore-sorting-2",
     subgroup = "ore-sorting-t2",
     energy_required = 1.5,
     enabled = false,
@@ -59,7 +59,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore3-chunk-processing",
-    category = "ore-sorting",
+    category = "ore-sorting-2",
     subgroup = "ore-sorting-t2",
     energy_required = 1.5,
     enabled = false,
@@ -86,7 +86,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore4-chunk-processing",
-    category = "ore-sorting",
+    category = "ore-sorting-2",
     subgroup = "ore-sorting-t2",
     energy_required = 1.5,
     enabled = false,
@@ -113,7 +113,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore5-chunk-processing",
-    category = "ore-sorting",
+    category = "ore-sorting-2",
     subgroup = "ore-sorting-t2",
     energy_required = 1.5,
     enabled = false,
@@ -140,7 +140,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore6-chunk-processing",
-    category = "ore-sorting",
+    category = "ore-sorting-2",
     subgroup = "ore-sorting-t2",
     energy_required = 1.5,
     enabled = false,

--- a/angelsrefining/prototypes/recipes/refining-dynamic/crystal-processing.lua
+++ b/angelsrefining/prototypes/recipes/refining-dynamic/crystal-processing.lua
@@ -5,7 +5,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore1-crystal-processing",
-    category = "ore-sorting-2",
+    category = "ore-sorting-3",
     subgroup = "ore-sorting-t3",
     energy_required = 2,
     enabled = false,
@@ -32,7 +32,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore2-crystal-processing",
-    category = "ore-sorting-2",
+    category = "ore-sorting-3",
     subgroup = "ore-sorting-t3",
     energy_required = 2,
     enabled = false,
@@ -59,7 +59,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore3-crystal-processing",
-    category = "ore-sorting-2",
+    category = "ore-sorting-3",
     subgroup = "ore-sorting-t3",
     energy_required = 2,
     enabled = false,
@@ -86,7 +86,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore4-crystal-processing",
-    category = "ore-sorting-2",
+    category = "ore-sorting-3",
     subgroup = "ore-sorting-t3",
     energy_required = 2,
     enabled = false,
@@ -113,7 +113,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore5-crystal-processing",
-    category = "ore-sorting-2",
+    category = "ore-sorting-3",
     subgroup = "ore-sorting-t3",
     energy_required = 2,
     enabled = false,
@@ -140,7 +140,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore6-crystal-processing",
-    category = "ore-sorting-2",
+    category = "ore-sorting-3",
     subgroup = "ore-sorting-t3",
     energy_required = 2,
     enabled = false,

--- a/angelsrefining/prototypes/recipes/refining-dynamic/pure-processing-mix.lua
+++ b/angelsrefining/prototypes/recipes/refining-dynamic/pure-processing-mix.lua
@@ -5,7 +5,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore-pure-mix1-processing", --tungsten
-    category = "ore-sorting-4",
+    category = "ore-sorting-5",
     subgroup = "ore-sorting-advanced",
     energy_required = 1.5,
     enabled = false,
@@ -38,7 +38,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore-pure-mix2-processing", --platinum
-    category = "ore-sorting-4",
+    category = "ore-sorting-5",
     subgroup = "ore-sorting-advanced",
     energy_required = 1.5,
     enabled = false,
@@ -71,7 +71,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore-pure-mix3-processing",
-    category = "ore-sorting-4",
+    category = "ore-sorting-5",
     subgroup = "ore-sorting-advanced",
     energy_required = 1.5,
     enabled = false,

--- a/angelsrefining/prototypes/recipes/refining-dynamic/pure-processing.lua
+++ b/angelsrefining/prototypes/recipes/refining-dynamic/pure-processing.lua
@@ -5,7 +5,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore1-pure-processing",
-    category = "ore-sorting-3",
+    category = "ore-sorting-4",
     subgroup = "ore-sorting-t4",
     energy_required = 2,
     enabled = false,
@@ -32,7 +32,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore2-pure-processing",
-    category = "ore-sorting-3",
+    category = "ore-sorting-4",
     subgroup = "ore-sorting-t4",
     energy_required = 2,
     enabled = false,
@@ -59,7 +59,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore3-pure-processing",
-    category = "ore-sorting-3",
+    category = "ore-sorting-4",
     subgroup = "ore-sorting-t4",
     energy_required = 2,
     enabled = false,
@@ -89,7 +89,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore4-pure-processing",
-    category = "ore-sorting-3",
+    category = "ore-sorting-4",
     subgroup = "ore-sorting-t4",
     energy_required = 2,
     enabled = false,
@@ -116,7 +116,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore5-pure-processing",
-    category = "ore-sorting-3",
+    category = "ore-sorting-4",
     subgroup = "ore-sorting-t4",
     energy_required = 2,
     enabled = false,
@@ -143,7 +143,7 @@ data:extend({
   {
     type = "recipe",
     name = "angelsore6-pure-processing",
-    category = "ore-sorting-3",
+    category = "ore-sorting-4",
     subgroup = "ore-sorting-t4",
     energy_required = 2,
     enabled = false,

--- a/angelsrefining/prototypes/recipes/refining-entity-angels.lua
+++ b/angelsrefining/prototypes/recipes/refining-entity-angels.lua
@@ -441,6 +441,34 @@ angelsmods.functions.RB.build({
       result = "ore-sorting-facility-4",
     },
   },
+  {
+    type = "recipe",
+    name = "ore-sorting-facility-5",
+    normal = {
+      energy_required = 5,
+      enabled = false,
+      ingredients = {
+        { type = "item", name = "sorter-5", amount = 1 },
+        { type = "item", name = "t5-plate", amount = 12 },
+        { type = "item", name = "t5-circuit", amount = 12 },
+        { type = "item", name = "t5-brick", amount = 12 },
+        { type = "item", name = "t5-gears", amount = 8 },
+      },
+      result = "ore-sorting-facility-5",
+    },
+    expensive = {
+      energy_required = 5 * buildingtime,
+      enabled = false,
+      ingredients = {
+        { type = "item", name = "sorter-5", amount = 1 },
+        { type = "item", name = "t5-plate", amount = 12 * buildingmulti },
+        { type = "item", name = "t5-circuit", amount = 12 * buildingmulti },
+        { type = "item", name = "t5-brick", amount = 12 * buildingmulti },
+        { type = "item", name = "t5-gears", amount = 8 * buildingmulti },
+      },
+      result = "ore-sorting-facility-5",
+    },
+  },
   --FILTRATION UNIT
   {
     type = "recipe",

--- a/angelsrefining/prototypes/recipes/refining-entity.lua
+++ b/angelsrefining/prototypes/recipes/refining-entity.lua
@@ -164,6 +164,16 @@ data:extend({
     },
     result = "ore-sorting-facility-4",
   },
+  {
+    type = "recipe",
+    name = "ore-sorting-facility-5",
+    energy_required = 5,
+    enabled = false,
+    ingredients = {
+      { type = "item", name = "ore-sorting-facility-4", amount = 1 },
+    },
+    result = "ore-sorting-facility-5",
+  },
   --FILTRATION UNIT
   {
     type = "recipe",

--- a/angelsrefining/prototypes/refining-category.lua
+++ b/angelsrefining/prototypes/refining-category.lua
@@ -18,6 +18,7 @@ data:extend({
   { type = "recipe-category", name = "ore-sorting-2" },
   { type = "recipe-category", name = "ore-sorting-3" },
   { type = "recipe-category", name = "ore-sorting-4" },
+  { type = "recipe-category", name = "ore-sorting-5" },
 
   { type = "recipe-category", name = "filtering" },
   { type = "recipe-category", name = "filtering-2" },

--- a/angelsrefining/prototypes/technology/refining-technology.lua
+++ b/angelsrefining/prototypes/technology/refining-technology.lua
@@ -252,6 +252,7 @@ data:extend({
     icon_size = 256,
     icon_mipmaps = 4,
     prerequisites = {
+      "advanced-ore-refining-1",
       "ore-crushing",
       "water-treatment",
       "automation-2",
@@ -638,7 +639,7 @@ data:extend({
     icon_size = 128,
     prerequisites = {
       "ore-floatation",
-      "advanced-ore-refining-1",
+      "advanced-ore-refining-2",
       "advanced-electronics",
       "chemical-science-pack",
     },
@@ -809,7 +810,7 @@ data:extend({
     icon_mipmaps = 4,
     prerequisites = {
       "ore-leaching",
-      "advanced-ore-refining-2",
+      "advanced-ore-refining-3",
       "advanced-electronics-2",
       "production-science-pack",
     },
@@ -899,6 +900,10 @@ data:extend({
       {
         type = "unlock-recipe",
         recipe = "ore-refinery-2",
+      },
+      {
+        type = "unlock-recipe",
+        recipe = "ore-sorting-facility-5",
       },
       {
         type = "unlock-recipe",

--- a/angelsrefining/prototypes/technology/water-treatment-technology.lua
+++ b/angelsrefining/prototypes/technology/water-treatment-technology.lua
@@ -73,8 +73,8 @@ data:extend({
     icon_size = 256,
     icon_mipmaps = 4,
     prerequisites = {
+      "slag-processing-1",
       "water-treatment",
-      "angels-coal-processing-2",
     },
     effects = {
       {

--- a/angelsrefining/prototypes/technology/water-treatment-technology.lua
+++ b/angelsrefining/prototypes/technology/water-treatment-technology.lua
@@ -74,7 +74,7 @@ data:extend({
     icon_mipmaps = 4,
     prerequisites = {
       "water-treatment",
-      "ore-floatation",
+      "angels-coal-processing-2",
     },
     effects = {
       {


### PR DESCRIPTION
Add a T5 Ore Sorting Facility.

Increase the required ore sorting facility tier for catalyst sorting recipes.
- T1: Crushed sorting
- T2: Crushed catalyst sorting, Chunk sorting
- T3: Chunk catalyst sorting, Crystal sorting
- T4: Crystal catalyst sorting, Pure sorting
- T5: Pure catalyst sorting

Update tech tree as required.

This change was made a long time ago in Sea Block and has worked well. PR to migrate the change to core Angel's, so it can be removed from Sea Block.