### PR TITLE
Makes lead and tin recipes use Angel's graphics instead of Bob's.

### DIFF
--- a/angelsrefining/info.json
+++ b/angelsrefining/info.json
@@ -10,6 +10,7 @@
   "dependencies": [
     "base >= 2.0.0",
     "~ angelsrefininggraphics >= 1.0.0",
+    "~ angelssmeltinggraphics >= 1.0.0",
     "(?) bobassembly >= 1.1.5",
     "? bobelectronics >= 1.1.6",
     "? bobenemies >= 1.1.5",

--- a/angelsrefining/prototypes/override/refining-override-smelting.lua
+++ b/angelsrefining/prototypes/override/refining-override-smelting.lua
@@ -56,6 +56,8 @@ end
 -------------------------------------------------------------------------------
 if ore_exists("lead") then
   local item_name = mods["angelssmelting"] and "angels-plate-lead" or "bob-lead-plate"
+  data.raw["item"][item_name].icon = "__angelssmeltinggraphics__/graphics/icons/plate-lead.png"
+  data.raw["item"][item_name].icon_size = 32
 
   OV.patch_recipes({
     {
@@ -74,6 +76,8 @@ end
 
 if ore_exists("tin") then
   local item_name = mods["angelssmelting"] and "angels-plate-tin" or "bob-tin-plate"
+  data.raw["item"][item_name].icon = "__angelssmeltinggraphics__/graphics/icons/plate-tin.png"
+  data.raw["item"][item_name].icon_size = 32
 
   OV.patch_recipes({
     {


### PR DESCRIPTION
Adds dependency on angelssmeltinggraphics for icons.

I'm sure this is wrong, this is just me trying to dip my toes as far as contributing towards the 2.0 migration.

I noticed that `angelssmelting` actually configures the icons inside `smelting-override-lead.lua` and `smelting-override-tin.lua`. Maybe this code needs to be moved to be somewhere shared instead?

Fixes #1040.