### PR TITLE
Fixed Angel's components icon scale

### DIFF
--- a/angelsindustries/prototypes/angels-industries-category.lua
+++ b/angelsindustries/prototypes/angels-industries-category.lua
@@ -58,12 +58,13 @@ data:extend({
       {
         icon = "__base__/graphics/item-group/intermediate-products.png",
         icon_size = 128,
+        scale = 0.5,
       },
       {
         icon = "__angelsrefininggraphics__/graphics/icons/void.png",
         icon_size = 32,
-        scale = 128 / 32 * 0.35,
-        shift = { 40, -40 },
+        scale = 64 / 32 * 0.35,
+        shift = { 20, -20 },
       },
     },
   },


### PR DESCRIPTION
Before and After:

![image](https://github.com/user-attachments/assets/a43fa363-4004-47d4-8f66-0afa4f4e6c7b)
![image](https://github.com/user-attachments/assets/bba75f03-dba5-452d-a167-9643091357ee)

I used the scaling-values of the other angels categories to fix the components icon.

Fixes #1058