### PR TITLE
Fix recipe patches

### DIFF
--- a/angelsrefining/prototypes/override/refining-override-water-treatment.lua
+++ b/angelsrefining/prototypes/override/refining-override-water-treatment.lua
@@ -278,7 +278,7 @@ if mods["bobplates"] then
       name = "bob-petroleum-gas-cracking",
       ingredients = { { name = "angels-water-purified", type = "fluid", amount = "water" } },
     },
-    { name = "coal-cracking", ingredients = { { name = "angels-water-purified", type = "fluid", amount = "water" } } },
+    { name = "bob-coal-cracking", ingredients = { { name = "angels-water-purified", type = "fluid", amount = "water" } } },
     {
       name = "bob-lithium-water-electrolysis",
       ingredients = { { name = "angels-water-purified", type = "fluid", amount = "water" } },

--- a/angelssmelting/prototypes/override/smelting-override-bobassembly.lua
+++ b/angelssmelting/prototypes/override/smelting-override-bobassembly.lua
@@ -18,12 +18,12 @@ if mods["bobassembly"] then
   angelsmods.functions.RB.set_fallback(
     "item",
     "assmach-5",
-    { { "block-mprocessing-5", 1 }, { "assembling-machine-4" } }
+    { { "block-mprocessing-5", 1 }, { "bob-assembling-machine-4" } }
   )
   angelsmods.functions.RB.set_fallback(
     "item",
     "assmach-6",
-    { { "block-mprocessing-5", 5 }, { "assembling-machine-5" } }
+    { { "block-mprocessing-5", 5 }, { "bob-assembling-machine-5" } }
   )
 
   OV.patch_recipes({
@@ -60,7 +60,7 @@ if mods["bobassembly"] then
       },
     },
     {
-      name = "assembling-machine-4",
+      name = "bob-assembling-machine-4",
       ingredients = {
         { "!!" },
         { type = "item", name = "assmach-4", amount = 1 },
@@ -71,7 +71,7 @@ if mods["bobassembly"] then
       },
     },
     {
-      name = "assembling-machine-5",
+      name = "bob-assembling-machine-5",
       ingredients = {
         { "!!" },
         { type = "item", name = "assmach-5", amount = 1 },
@@ -82,7 +82,7 @@ if mods["bobassembly"] then
       },
     },
     {
-      name = "assembling-machine-6",
+      name = "bob-assembling-machine-6",
       ingredients = {
         { "!!" },
         { type = "item", name = "assmach-6", amount = 1 },

--- a/angelssmelting/prototypes/override/smelting-override-platinum.lua
+++ b/angelssmelting/prototypes/override/smelting-override-platinum.lua
@@ -69,7 +69,7 @@ end
 if angelsmods.trigger.smelting_products["platinum"].wire then
   OV.patch_recipes({
     {
-      name = "processing-electronics",
+      name = "bob-processing-electronics",
       ingredients = {
         { type = "item", name = "angels-wire-platinum", amount = "bob-gilded-copper-cable" },
       },

--- a/angelssmelting/prototypes/override/smelting-override-stone.lua
+++ b/angelssmelting/prototypes/override/smelting-override-stone.lua
@@ -35,7 +35,7 @@ OV.patch_recipes({
   },
   { name = "hazard-concrete", subgroup = "angels-stone-casting", order = "h[concrete]-c" },
   { name = "refined-concrete", subgroup = "angels-stone-casting", order = "h[concrete]-d" },
-  { name = "hazard-refined-concrete", subgroup = "angels-stone-casting", order = "h[concrete]-e" },
+  { name = "refined-hazard-concrete", subgroup = "angels-stone-casting", order = "h[concrete]-e" },
 })
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Added several missing bob- prefixes in recipe patches and fixed the wrong vanilla refined-hazard-concrete name. This PR fixes KompetenzAirbag/SeaBlock#46.