### PR TITLE
Removed all kovarex tech references (angelspetrochem)

### DIFF
--- a/angelspetrochem/prototypes/override/angelspetrochem-nuclear.lua
+++ b/angelspetrochem/prototypes/override/angelspetrochem-nuclear.lua
@@ -105,7 +105,6 @@ data.raw.recipe["nuclear-fuel-reprocessing"].icon = nil
 OV.disable_recipe("kovarex-enrichment-process")
 OV.add_unlock("nuclear-power", "angels-uranium-fuel-cell")
 data.raw.item["uranium-fuel-cell"].fuel_value = "2GJ"
-data.raw.technology["kovarex-enrichment-process"].unit.count = 10 -- down from 1500 (Considering empty)
 
 -----------------------------------------------------------------------------
 -- VANILLA POWER STUFFS -----------------------------------------------------

--- a/angelspetrochem/prototypes/override/base-game.lua
+++ b/angelspetrochem/prototypes/override/base-game.lua
@@ -233,3 +233,5 @@ data.raw.technology["kovarex-enrichment-process"].hidden = true
 
 OV.remove_prereq("atomic-bomb", "kovarex-enrichment-process")
 OV.add_prereq("atomic-bomb", "uranium-processing")
+
+OV.add_prereq("angels-nuclear-fuel", "uranium-processing")

--- a/angelspetrochem/prototypes/override/base-game.lua
+++ b/angelspetrochem/prototypes/override/base-game.lua
@@ -225,3 +225,11 @@ if data.raw["reactor"]["nuclear-reactor"] then
     light_intensity_to_size_coefficient = 0,
   }
 end
+
+-------------------------------------------------------------------------------
+-- NUCLEAR TECHNOLOGIES -------------------------------------------------------
+-------------------------------------------------------------------------------
+data.raw.technology["kovarex-enrichment-process"].hidden = true
+
+OV.remove_prereq("atomic-bomb", "kovarex-enrichment-process")
+OV.add_prereq("atomic-bomb", "uranium-processing")

--- a/angelspetrochem/prototypes/override/bobplates.lua
+++ b/angelspetrochem/prototypes/override/bobplates.lua
@@ -277,6 +277,9 @@ if mods["bobplates"] then
     OV.add_prereq("angels-advanced-chemistry-2", "bob-zinc-processing")
     OV.add_prereq("angels-nitrogen-processing-4", "bob-tungsten-alloy-processing")
   end
-  
+
   OV.add_prereq("angels-advanced-chemistry-5", "bob-advanced-processing-unit")
+
+  -- Kovarex Enrichment
+  OV.remove_prereq("bobingabout-enrichment-process", "kovarex-enrichment-process")
 end

--- a/angelspetrochem/prototypes/technology/petrochem-solids.lua
+++ b/angelspetrochem/prototypes/technology/petrochem-solids.lua
@@ -241,7 +241,6 @@ data:extend({
     icon = "__angelspetrochemgraphics__/graphics/technology/nuclear-fuel.png",
     icon_size = 128,
     prerequisites = {
-      "kovarex-enrichment-process",
       "utility-science-pack",
       "rocket-fuel",
     },


### PR DESCRIPTION
The technology kovarex-enrichment-process has no unlocks and thus the science cost was set to 10 packs. I think it is much cleaner and less confusing to hide the technology entirely. The technologies which depended on that now only require uranium-processing (and their other previous prerequisites).