### PR TITLE
Fixed bob artifacts

### DIFF
--- a/angelsbioprocessing/data.lua
+++ b/angelsbioprocessing/data.lua
@@ -9,8 +9,10 @@ angelsmods.trigger = angelsmods.trigger or {}
 angelsmods.trigger.lab_ignore_token = angelsmods.trigger.lab_ignore_token or {}
 angelsmods.trigger.lab_ignore_token["bob-lab-alien"] = true
 --ARTIFACTS
-angelsmods.trigger.artifacts = angelsmods.trigger.artifacts or {}
 if bobmods and bobmods.enemies and data.raw.item["bob-small-alien-artifact-blue"] then
+  if not angelsmods.trigger.artifacts then
+    angelsmods.trigger.artifacts = {}
+  end
   angelsmods.trigger.artifacts["red"] = true
   angelsmods.trigger.artifacts["yellow"] = true
   angelsmods.trigger.artifacts["orange"] = true

--- a/angelsbioprocessing/prototypes/overrides/bio-processing-override-artifacts.lua
+++ b/angelsbioprocessing/prototypes/overrides/bio-processing-override-artifacts.lua
@@ -2,20 +2,20 @@ local OV = angelsmods.functions.OV
 
 local contains_artifact_creation = false
 local artifact = {
-  ["reg"] = (bobmods and bobmods.plates and bobmods.enemies) and "bob-alien-artifact" or "angels-alien-artifact",
-  ["small-reg"] = (bobmods and bobmods.plates and bobmods.enemies) and "bob-small-alien-artifact" or "angels-small-alien-artifact",
-  ["red"] = (bobmods and bobmods.plates and bobmods.enemies) and "bob-alien-artifact-red" or "angels-alien-artifact-red",
-  ["small-red"] = (bobmods and bobmods.plates and bobmods.enemies) and "bob-small-alien-artifact-red" or "angels-small-alien-artifact-red",
-  ["yellow"] = (bobmods and bobmods.plates and bobmods.enemies) and "bob-alien-artifact-yellow" or "angels-alien-artifact-yellow",
-  ["small-yellow"] = (bobmods and bobmods.plates and bobmods.enemies) and "bob-small-alien-artifact-yellow" or "angels-small-alien-artifact-yellow",
-  ["orange"] = (bobmods and bobmods.plates and bobmods.enemies) and "bob-alien-artifact-orange" or "angels-alien-artifact-orange",
-  ["small-orange"] = (bobmods and bobmods.plates and bobmods.enemies) and "bob-small-alien-artifact-orange" or "angels-small-alien-artifact-orange",
-  ["green"] = (bobmods and bobmods.plates and bobmods.enemies) and "bob-alien-artifact-green" or "angels-alien-artifact-green",
-  ["small-green"] = (bobmods and bobmods.plates and bobmods.enemies) and "bob-small-alien-artifact-green" or "angels-small-alien-artifact-green",
-  ["blue"] = (bobmods and bobmods.plates and bobmods.enemies) and "bob-alien-artifact-blue" or "angels-alien-artifact-blue",
-  ["small-blue"] = (bobmods and bobmods.plates and bobmods.enemies) and "bob-small-alien-artifact-blue" or "angels-small-alien-artifact-blue",
-  ["purple"] = (bobmods and bobmods.plates and bobmods.enemies) and "bob-alien-artifact-purple" or "angels-alien-artifact-purple",
-  ["small-purple"] = (bobmods and bobmods.plates and bobmods.enemies) and "bob-small-alien-artifact-purple" or "angels-small-alien-artifact-purple",
+  ["reg"] = (bobmods and bobmods.enemies) and "bob-alien-artifact" or "angels-alien-artifact",
+  ["small-reg"] = (bobmods and bobmods.enemies) and "bob-small-alien-artifact" or "angels-small-alien-artifact",
+  ["red"] = (bobmods and bobmods.enemies) and "bob-alien-artifact-red" or "angels-alien-artifact-red",
+  ["small-red"] = (bobmods and bobmods.enemies) and "bob-small-alien-artifact-red" or "angels-small-alien-artifact-red",
+  ["yellow"] = (bobmods and bobmods.enemies) and "bob-alien-artifact-yellow" or "angels-alien-artifact-yellow",
+  ["small-yellow"] = (bobmods and bobmods.enemies) and "bob-small-alien-artifact-yellow" or "angels-small-alien-artifact-yellow",
+  ["orange"] = (bobmods and bobmods.enemies) and "bob-alien-artifact-orange" or "angels-alien-artifact-orange",
+  ["small-orange"] = (bobmods and bobmods.enemies) and "bob-small-alien-artifact-orange" or "angels-small-alien-artifact-orange",
+  ["green"] = (bobmods and bobmods.enemies) and "bob-alien-artifact-green" or "angels-alien-artifact-green",
+  ["small-green"] = (bobmods and bobmods.enemies) and "bob-small-alien-artifact-green" or "angels-small-alien-artifact-green",
+  ["blue"] = (bobmods and bobmods.enemies) and "bob-alien-artifact-blue" or "angels-alien-artifact-blue",
+  ["small-blue"] = (bobmods and bobmods.enemies) and "bob-small-alien-artifact-blue" or "angels-small-alien-artifact-blue",
+  ["purple"] = (bobmods and bobmods.enemies) and "bob-alien-artifact-purple" or "angels-alien-artifact-purple",
+  ["small-purple"] = (bobmods and bobmods.enemies) and "bob-small-alien-artifact-purple" or "angels-small-alien-artifact-purple",
 }
 -------------------------------------------------------------------------------
 -- RED ARTIFACTS --------------------------------------------------------------


### PR DESCRIPTION
The bobplates check in bioprocessing resulted in a startup error when only bobenemies and angelsbioprocessing is enabled. The creation check for angelsmods.trigger.artifacts was also needed.

This is also fixed in the referenced PR. If the referenced PR gets merged this PR can be closed without merging.