### PR TITLE
Fix Seafloor pump circuit connectors (#1028)

### DIFF
--- a/angelsrefining/prototypes/buildings/sea-pump.lua
+++ b/angelsrefining/prototypes/buildings/sea-pump.lua
@@ -292,7 +292,7 @@ data:extend({
         height = 160,
       },
     },
-    circuit_connector = circuit_connector_definitions["offshore-pump"],
+    circuit_connector = circuit_connector_definitions["angels-seafloor-pump"],
     circuit_wire_max_distance = default_circuit_wire_max_distance,
   },
 })

--- a/angelsrefining/prototypes/buildings/seafloor-pump.lua
+++ b/angelsrefining/prototypes/buildings/seafloor-pump.lua
@@ -1,6 +1,13 @@
 local hit_effects = require("__base__/prototypes/entity/hit-effects")
 local sounds = require("__base__/prototypes/entity/sounds")
 
+circuit_connector_definitions["angels-seafloor-pump"] = circuit_connector_definitions.create_vector(universal_connector_template, {
+  { variation = 31, main_offset = util.by_pixel( 46.5, -16), shadow_offset = util.by_pixel( 46.5, -16), show_shadow = true },
+  { variation = 30, main_offset = util.by_pixel( 17.5,  25.25), shadow_offset = util.by_pixel( 17.5,  25.25), show_shadow = true },
+  { variation = 28, main_offset = util.by_pixel( 46.125,  4.375), shadow_offset = util.by_pixel( 46.125,  4.375), show_shadow = true },
+  { variation = 26, main_offset = util.by_pixel(-17.5,  25.25), shadow_offset = util.by_pixel(-17.5,  25.25), show_shadow = true },
+})
+
 data:extend({
   {
     type = "item",
@@ -121,7 +128,7 @@ data:extend({
       scale = 0.5,
       x = 3 * 64,
     },
-    circuit_connector = circuit_connector_definitions["offshore-pump"],
+    circuit_connector = circuit_connector_definitions["angels-seafloor-pump"],
     circuit_wire_max_distance = default_circuit_wire_max_distance,
   },
 })


### PR DESCRIPTION
This is a still-WIP fix for #1028.

Currently the commit has two approaches for the circuit connector replacements (one is commented out):
## Remaining steps
- [x] Settle on the connector placement approach
- [x] Give the placement a pixel-accurate once-over (This is still the quick and dirty version :wink:)
- [x] Cleanup
  - [x] Remove the not-chosen placement
  - [x] Remove the note comments I still have in there (The cardinal directions)

## Screenshots
### Approach 1: Side of pump
I personally prefer this one
<img width="1034" height="982" alt="Image" src="https://github.com/user-attachments/assets/96716589-42fc-421e-a34f-4aa37bf45602" />

<img width="1043" height="983" alt="Image" src="https://github.com/user-attachments/assets/d8e4639e-a2b8-49e0-8239-1fe2c74dcb95" />

### Approach 2: Top of pump
<img width="1034" height="982" alt="Image" src="https://github.com/user-attachments/assets/82f78b0b-dfcd-4346-963e-2605b862507e" />

<img width="1043" height="983" alt="Image" src="https://github.com/user-attachments/assets/bbec728d-cd99-4ff0-baac-1b0d6e70961b" />


