### PR TITLE
fix incorrect icon location

### DIFF
--- a/angelsindustries/prototypes/angels-industries-category.lua
+++ b/angelsindustries/prototypes/angels-industries-category.lua
@@ -418,7 +418,7 @@ data:extend({
     order = "la[angels]-e[industries]-d",
     icons = {
       {
-        icon = "__angelsindustriesgraphics__/graphics/technology/cargo-roboport-tech.png",
+        icon = "__angelsaddons-bots__/graphics/technology/cargo-roboport-tech.png",
         icon_size = 128,
         scale = 0.5,
       },


### PR DESCRIPTION
The icon path for the `angels-logistics` item group was not updated to reflect its new location after angeladdons-bots got separated from industries. 