### PR TITLE
Change enemy multiplier slider to a map preset

### DIFF
--- a/angelsrefining/locale/en/map-generation.cfg
+++ b/angelsrefining/locale/en/map-generation.cfg
@@ -1,0 +1,5 @@
+[map-gen-preset-name]
+angels-default=Default (Angels)
+
+[map-gen-preset-description]
+angels-default=Default settings recommended for your first time playing Angel's mods - Enemies are disabled.

--- a/angelsrefining/locale/en/ore-refining.cfg
+++ b/angelsrefining/locale/en/ore-refining.cfg
@@ -113,11 +113,6 @@ angels-ore6=Bobmonium
 
 angels-fissure=Fissure
 
-angels-biter-slider=Angel's enemy multiplier
-
-[autoplace-control-description]
-angels-biter-slider=Size of 100% or lower disables biters completely.\nSize of 600% gives "normal" biter size and frequency.\nFrequency has no effect.
-
 [item-name]
 angels-slag=Slag
 angels-filter-frame=Filter frame

--- a/angelsrefining/locale/en/welcome-message.cfg
+++ b/angelsrefining/locale/en/welcome-message.cfg
@@ -1,10 +1,10 @@
 [angels-welcome-message-gui]
-title=Angel's tweaks to map settings
+title=Angel's recommended map settings
 confirm-button=Continue
 
 [angels-welcome-message]
-intro=Dear player,\nThe default map settings are balanced to improve your Angel's experience. The tweaked settings are listed below.
-outro=To change any of these settings return to the new game menu and tweak the respective settings. You find more info about the settings by hovering the info icons.
+intro=Dear player,\nWelcome to Angel's mods! If this is your first time playing these mods, we suggest playing without biters for your first run.
+outro=You can also simply select the Angel's Default Preset during map generation.
 
 [angels-welcome-message-settings]
 disabled=[color=red]disabled[/color]
@@ -17,6 +17,6 @@ expansion-setting=Enemy expansion is currently __1__.
 
 [angels-welcome-message-settings-tooltip]
 pollution-setting=To change the pollution setting, go into the "Advanced" tab of the Map generator and toggle the checkbox near "Pollution".
-enemy-setting=To change the enemy setting, go into the "Enemy" tab of the Map generator and tweak the "Angel's enemy multiplier" size slider.
+enemy-setting=To change the enemy setting, go into the "Enemy" tab of the Map generator and enable the "No enemies" or "Peaceful mode" settings.
 evolution-setting=To change the enemy evolution setting, go into the "Enemy" tab of the Map generator and toggle the checkbox for "Evolution".
 expansion-setting=To change the enemy expansion setting, go into the "Enemy" tab of the Map generator and toggle the checkbox for "Enemy expansion".

--- a/angelsrefining/locale/en/welcome-message.cfg
+++ b/angelsrefining/locale/en/welcome-message.cfg
@@ -7,8 +7,9 @@ intro=Dear player,\nWelcome to Angel's mods! If this is your first time playing 
 outro=You can also simply select the Angel's Default Preset during map generation.
 
 [angels-welcome-message-settings]
-disabled=[color=red]disabled[/color]
-enabled=[color=green]enabled[/color]
+enabled=[color=red]enabled[/color][virtual-signal=signal-alert]
+disabled=[color=green]disabled[/color][virtual-signal=signal-check]
+peaceful=[color=green]peaceful[/color][virtual-signal=signal-check]
 
 pollution-setting=Pollution is currently __1__.
 enemy-setting=Enemies are currently __1__.

--- a/angelsrefining/prototypes/generation/map-gen-presets.lua
+++ b/angelsrefining/prototypes/generation/map-gen-presets.lua
@@ -1,26 +1,22 @@
 if mods["angelsexploration"] then
   -- angels exploration takes care of this
 else
-  local map_settings = data.raw["map-settings"]["map-settings"]
-  map_settings.pollution.enabled = false
-  map_settings.enemy_evolution.enabled = false
-  map_settings.enemy_expansion.enabled = false
-
-  local probability = data.raw["noise-expression"]["enemy_base_probability"]
-  probability.local_expressions["old_probability"] = probability.expression
-  probability.local_expressions["angels_biter_slider"] = "if(var('control:angels-biter-slider:size') >= 6, 1, 0)"
-  probability.expression = "old_probability * angels_biter_slider"
-  data.raw.planet["nauvis"].map_gen_settings.autoplace_controls["angels-biter-slider"] = {}
-
-  data:extend({
-    {
-      type = "autoplace-control",
-      name = "angels-biter-slider",
-      richness = false,
-      can_be_disabled = false,
-      order = "d-a",
-      category = "enemy",
-      localised_description = { "autoplace-control-description.angels-biter-slider" },
+  data.raw["map-gen-presets"]["default"]["angels-default"] = {
+    order = "a",
+    basic_settings = {
+      peaceful_mode = true,
+      no_enemies_mode = true,
     },
-  })
+    advanced_settings = {
+      pollution = {
+        enabled = false,
+      },
+      enemy_evolution = {
+        enabled = false,
+      },
+      enemy_expansion = {
+        enabled = false,
+      },
+    }
+  }
 end

--- a/angelsrefining/src/welcome_dialog.lua
+++ b/angelsrefining/src/welcome_dialog.lua
@@ -88,19 +88,19 @@ function welcome_dialog:create_welcome_dialog(player_index)
     tooltip = { "angels-welcome-message-settings-tooltip.pollution-setting" },
   })
 
-  local enemySizeSetting = (((player.surface.map_gen_settings["autoplace_controls"] or {})["angels-biter-slider"] or {["size"] = 0})["size"] >= 6) and
-    (((player.surface.map_gen_settings["autoplace_controls"] or {})["enemy-base"] or {["size"] = 0})["size"] > 0)
-    and "enabled" or "disabled"
+  local peaceful_mode = player.surface.map_gen_settings.peaceful_mode
+  local no_enemies_mode = player.surface.map_gen_settings.no_enemies_mode
+  local enemies_text = (not no_enemies_mode and not peaceful_mode and "enabled") or "disabled"
   welcomeFrameContent.add({
-    type = "label",
-    name = "enemy_size_message",
-    caption = {
-      "",
-      "     ",
-      { "angels-welcome-message-settings.enemy-setting", { "angels-welcome-message-settings." .. enemySizeSetting } },
-      " [img=info]",
-    },
-    tooltip = { "angels-welcome-message-settings-tooltip.enemy-setting" },
+  type = "label",
+  name = "enemy_size_message",
+  caption = {
+    "",
+    "     ",
+    { "angels-welcome-message-settings.enemy-setting", { "angels-welcome-message-settings." .. enemies_text } },
+    " [img=info]",
+  },
+  tooltip = { "angels-welcome-message-settings-tooltip.enemy-setting" },
   })
 
   local enemyEvolutionSetting = game.map_settings.enemy_evolution.enabled and "enabled" or "disabled"

--- a/angelsrefining/src/welcome_dialog.lua
+++ b/angelsrefining/src/welcome_dialog.lua
@@ -90,6 +90,7 @@ function welcome_dialog:create_welcome_dialog(player_index)
 
   local peaceful_mode = player.surface.map_gen_settings.peaceful_mode
   local no_enemies_mode = player.surface.map_gen_settings.no_enemies_mode
+  local enemies_text = (no_enemies_mode and "disabled") or (peaceful_mode and "peaceful") or "enabled"
   local enemies_text = (not no_enemies_mode and not peaceful_mode and "enabled") or "disabled"
   welcomeFrameContent.add({
   type = "label",


### PR DESCRIPTION
This tackles #1177 

The enemy multiplier slider was used as a janky boolean option from the map generation settings.
It would disable enemies by overriding the enemy spawner generation chance to 0.

For issues with that prior approach, see this comment: https://github.com/Arch666Angel/mods/issues/1177#issuecomment-3566722654