### PR TITLE
Change tree autoplace order from 'yaa' to 'yab'

### DIFF
--- a/angelsbioprocessing/prototypes/buildings/trees.lua
+++ b/angelsbioprocessing/prototypes/buildings/trees.lua
@@ -160,7 +160,7 @@ data:extend({
     order = "z-b",
     impact_category = "wood",
     autoplace = {
-      order = "yaa",
+      order = "yab",
       probability_expression = 0.000025,
       tile_restriction = { "dirt-1", "dirt-2", "dirt-3", "dirt-4", "dirt-5", "dirt-6", "dirt-7" },
     },


### PR DESCRIPTION
Fixes the lack of spawned Swamp Trees on map.

Looks like sharing the same `order` and `tile_restriction` prevents the swamp from being spawned, since desert tree overrides it.
Confirmed that it works on existing save, unexplored tiles now contain swamp trees.