### PR TITLE
Use 7zip if available to create zip files

### DIFF
--- a/build_angelmods.sh
+++ b/build_angelmods.sh
@@ -23,7 +23,9 @@ function process() {
   fi
   $(eval $cmd)
   cd "${dirname}/../"
-  zip -q -r "${release}.zip" "${release}/"
+  rm -f "${release}.zip"
+  7za -bso0 -mx1 -mmt16 a "${release}.zip" "${release}"
+#  zip -q -r "${release}.zip" "${release}/"
   rm -rf "${release}/"
   echo "Released ${release}"
 }

--- a/build_angelmods.sh
+++ b/build_angelmods.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [ -f "`which 7za 2>&1`" ]; then
+	archive_command="7za -bso0 -mx1 a"
+else
+	archive_command="zip -q -r"
+fi
+
 function process() {
   dirname="$(cd "$(dirname "$1")"; pwd -P)/$(basename "$1")"
   ignores="build.sh modportal/ .DS_Store README.md .git/ .gitignore"
@@ -24,8 +30,7 @@ function process() {
   $(eval $cmd)
   cd "${dirname}/../"
   rm -f "${release}.zip"
-  7za -bso0 -mx1 -mmt16 a "${release}.zip" "${release}"
-#  zip -q -r "${release}.zip" "${release}/"
+  $archive_command "${release}.zip" "${release}"
   rm -rf "${release}/"
   echo "Released ${release}"
 }


### PR DESCRIPTION
I have added the option to use 7zip if installed to the (bash) build script. This improves zip creation performance on a multicore machine, for me it is about 3x. The size difference of the resulting files is marginal.
-- with 7zip --
real	0m6,292s
user 0m22,831s
sys	0m3,988s
total size of zip files: 779596k

-- with zip --
real	0m18,029s
user 0m14,783s
sys	0m2,621s
total size of zip files: 778792k