### PR TITLE
[codex] Add Factorio 2.0 startup compatibility fixes

### DIFF
--- a/angelsaddons-storage/info.json
+++ b/angelsaddons-storage/info.json
@@ -1,7 +1,7 @@
 {
   "name": "angelsaddons-storage",
   "version": "0.0.10",
-  "factorio_version": "1.1",
+  "factorio_version": "2.0",
   "title": "Angel's Addons - Storage Options",
   "author": "Arch666Angel",
   "contact": "https://discord.gg/ff5p6KE",

--- a/angelsbioprocessing/info.json
+++ b/angelsbioprocessing/info.json
@@ -1,7 +1,7 @@
 {
   "name": "angelsbioprocessing",
   "version": "0.7.27",
-  "factorio_version": "1.1",
+  "factorio_version": "2.0",
   "title": "Angel's Bioprocessing",
   "author": "Arch666Angel",
   "contact": "https://discord.gg/ff5p6KE",

--- a/angelsbioprocessing/prototypes/buildings/bio-tile.lua
+++ b/angelsbioprocessing/prototypes/buildings/bio-tile.lua
@@ -1,4 +1,11 @@
-local pollution_absorption_per_second = data.raw["tile"]["out-of-map"].pollution_absorption_per_second
+-- Factorio 2.0 renamed tile pollution absorption from
+-- `pollution_absorption_per_second` to `absorptions_per_second.pollution`.
+-- Read either shape here because this file may run after base 2.0 prototypes
+-- but before all compatibility shims have normalized Angel's generated tiles.
+local pollution_absorption_per_second = (
+  data.raw["tile"]["out-of-map"].pollution_absorption_per_second
+  or data.raw["tile"]["out-of-map"].absorptions_per_second.pollution
+)
   * (2 ^ (settings.startup["angels-bio-tile-pollution-absorbtion-multiplier"].value - 1))
 data:extend({
   {
@@ -26,7 +33,10 @@ data:extend({
     walking_speed_modifier = 1.3,
     layer = 80,
     decorative_removal_probability = 1,
-    pollution_absorption_per_second = pollution_absorption_per_second,
+    -- 2.0 tile absorption shape.  Keep the local variable name above because
+    -- the setting/locale text still describes this as pollution absorbed per
+    -- second from the player's point of view.
+    absorptions_per_second = { pollution = pollution_absorption_per_second },
     variants = {
       main = {
         {

--- a/angelsbioprocessing/prototypes/overrides/bio-processing-override-bobmodules.lua
+++ b/angelsbioprocessing/prototypes/overrides/bio-processing-override-bobmodules.lua
@@ -2,6 +2,15 @@ local OV = angelsmods.functions.OV
 local move_item = angelsmods.functions.move_item
 
 if mods["bobmodules"] then
+  local function module_technology(name)
+    return data.raw.technology[name] or data.raw.technology[name:gsub("^effectivity", "efficiency")]
+  end
+
+  local function module_name(name)
+    local prototype = data.raw.module[name] or data.raw.module[name:gsub("^effectivity", "efficiency")]
+    return prototype and prototype.name or name
+  end
+
   -----------------------------------------------------------------------------
   -- EXISTING MODULES CATEGORY ------------------------------------------------
   -----------------------------------------------------------------------------
@@ -435,10 +444,13 @@ if mods["bobmodules"] then
       i > 1 and "productivity-module-" .. i or "productivity-module",
       i > 1 and "effectivity-module-" .. i or "effectivity-module",
     }) do
-      for _, ingredient in pairs(data.raw.technology[tech_name].unit.ingredients) do
-        if not ingredients_added[ingredient.name or ingredient[1]] then
-          ingredients_added[ingredient.name or ingredient[1]] = true
-          table.insert(ingredients, util.table.deepcopy(ingredient))
+      local tech = module_technology(tech_name)
+      if tech and tech.unit then
+        for _, ingredient in pairs(tech.unit.ingredients) do
+          if not ingredients_added[ingredient.name or ingredient[1]] then
+            ingredients_added[ingredient.name or ingredient[1]] = true
+            table.insert(ingredients, util.table.deepcopy(ingredient))
+          end
         end
       end
     end
@@ -457,10 +469,13 @@ if mods["bobmodules"] then
       "productivity-module-" .. (i < 6 and 4 or 6),
       "effectivity-module-" .. (i < 6 and 4 or 6),
     }) do
-      for _, ingredient in pairs(data.raw.technology[tech_name].unit.ingredients) do
-        if not ingredients_added[ingredient.name or ingredient[1]] then
-          ingredients_added[ingredient.name or ingredient[1]] = true
-          table.insert(ingredients, util.table.deepcopy(ingredient))
+      local tech = module_technology(tech_name)
+      if tech and tech.unit then
+        for _, ingredient in pairs(tech.unit.ingredients) do
+          if not ingredients_added[ingredient.name or ingredient[1]] then
+            ingredients_added[ingredient.name or ingredient[1]] = true
+            table.insert(ingredients, util.table.deepcopy(ingredient))
+          end
         end
       end
     end
@@ -471,6 +486,10 @@ if mods["bobmodules"] then
         solder_amount = solder_amount + 1
       end
     end
+    local productivity_module_name = module_name("productivity-module-" .. i)
+    local efficiency_module_name = module_name("effectivity-module-" .. i)
+    local productivity_technology =
+      module_technology("productivity-module-" .. (i < 6 and 4 or 6)) or data.raw.technology["modules"]
     data:extend({
       {
         type = "module",
@@ -497,8 +516,8 @@ if mods["bobmodules"] then
         enabled = false,
         ingredients = {
           --{type = "item", name = "solder", amount = solder_amount},
-          { type = "item", name = "productivity-module-" .. i, amount = 1 },
-          { type = "item", name = "effectivity-module-" .. i, amount = 1 },
+          { type = "item", name = productivity_module_name, amount = 1 },
+          { type = "item", name = efficiency_module_name, amount = 1 },
           { type = "item", name = "token-bio", amount = 1 },
         },
         energy_required = 15,
@@ -513,8 +532,8 @@ if mods["bobmodules"] then
         order = "c-a",
         prerequisites = {
           "angels-bio-yield-module-" .. i - 1,
-          "productivity-module-" .. i,
-          "effectivity-module-" .. i,
+          productivity_module_name,
+          efficiency_module_name,
         },
         effects = {
           {
@@ -525,7 +544,7 @@ if mods["bobmodules"] then
         unit = {
           count = i < 6 and ((i - 1) * 50) or ((i - 3) * 100),
           ingredients = ingredients,
-          time = data.raw.technology["productivity-module-" .. (i < 6 and 4 or 6)].unit.time,
+          time = productivity_technology and productivity_technology.unit and productivity_technology.unit.time or 60,
         },
       },
     })

--- a/angelsbioprocessing/prototypes/recipes/bio-module.lua
+++ b/angelsbioprocessing/prototypes/recipes/bio-module.lua
@@ -42,7 +42,10 @@ data:extend({
   },
 })
 
-if mods["boblibrary"] then
+-- Bob's 2.0 dev branch can be present without the old module helper library
+-- layout used by Angel's 1.1 code.  Excluding these modules from productivity
+-- effects is nice-to-have; guard it so missing helper tables do not block load.
+if bobmods and bobmods.lib and bobmods.lib.module then
   for _, module_name in pairs({
     "angels-bio-yield-module",
     "angels-bio-yield-module-2",

--- a/angelsinfiniteores/prototypes/generation/resource-builder.lua
+++ b/angelsinfiniteores/prototypes/generation/resource-builder.lua
@@ -1,6 +1,10 @@
-local noise = require("noise")
-local tne = noise.to_noise_expression
 local resource_autoplace = require("resource-autoplace")
+
+-- Factorio 2.0 removed the old `particle` prototype type used by Angel's
+-- 1.1 resource generator.  Ore particles are now `optimized-particle`
+-- prototypes, so keep a local reference to that table and generate/look up the
+-- new type everywhere this builder handles resource mining particles.
+local particles = data.raw["optimized-particle"] or {}
 
 if not angelsmods.functions.make_resource then
   --Create autoplace
@@ -19,7 +23,7 @@ if not angelsmods.functions.make_resource then
 
   --Create particles
   local function make_particle(input)
-    if not data.raw.particle[input.name .. "-particle"] then
+    if not particles[input.name .. "-particle"] then
       data:extend({
         {
           type = "optimized-particle",
@@ -944,7 +948,7 @@ if not angelsmods.functions.make_resource then
         generate_presets(input.name)
         --Create Particle if resource yields items
         if input.type == "item" then
-          if input.get and data.raw.particle[input.get .. "-particle"] then
+          if input.get and particles[input.get .. "-particle"] then
             input.particle = input.get .. "-particle"
           else
             make_particle(input)

--- a/angelspetrochem/info.json
+++ b/angelspetrochem/info.json
@@ -1,7 +1,7 @@
 {
   "name": "angelspetrochem",
   "version": "0.9.26",
-  "factorio_version": "1.1",
+  "factorio_version": "2.0",
   "title": "Angel's Petrochemical Processing",
   "author": "Arch666Angel",
   "contact": "https://discord.gg/ff5p6KE",

--- a/angelspetrochem/prototypes/override/angelspetrochem.lua
+++ b/angelspetrochem/prototypes/override/angelspetrochem.lua
@@ -19,7 +19,8 @@ if mods["bobplates"] and data.raw["fluid"]["deuterium"] then
   OV.disable_technology("deuterium-processing")
   OV.add_prereq("water-chemistry-2", "nuclear-fuel-reprocessing")
 
-  if mods["bobrevamp"] and mods["bobpower"] and settings.startup["bobmods-revamp-nuclear"].value == true then
+  local bob_revamp_nuclear = settings.startup["bobmods-revamp-nuclear"]
+  if mods["bobrevamp"] and mods["bobpower"] and bob_revamp_nuclear and bob_revamp_nuclear.value == true then
     -- deuterium-fuel-cell will be unlocked by bob-nuclear-power-3
   else
     OV.add_unlock("water-chemistry-2", "deuterium-fuel-cell")

--- a/angelspetrochem/prototypes/override/bobplates.lua
+++ b/angelspetrochem/prototypes/override/bobplates.lua
@@ -92,7 +92,7 @@ local turret_params = data.raw["fluid-turret"]["flamethrower-turret"].attack_par
 
 if mods["bobplates"] then
   for fluid, vals in pairs(Energy_table) do
-    if vals.fv then
+    if vals.fv and data.raw.fluid[fluid] then
       data.raw.fluid[fluid].fuel_value = (math.floor(vals.fv / 5 + 0.5)) * 5 .. "kJ"
       data.raw.fluid[fluid].emissions_multiplier = vals.em or data.raw.fluid[fluid].emissions_multiplier or 1
       if vals.turr ~= false then
@@ -104,8 +104,10 @@ if mods["bobplates"] then
     end
   end
   --fuel oil balancing
-  data.raw.recipe["enriched-fuel-from-liquid-fuel"].ingredients =
-    { { type = "fluid", name = "liquid-fuel", amount = 100 } } --up from 20
+  if data.raw.recipe["enriched-fuel-from-liquid-fuel"] then
+    data.raw.recipe["enriched-fuel-from-liquid-fuel"].ingredients =
+      { { type = "fluid", name = "liquid-fuel", amount = 100 } } --up from 20
+  end
 end
 
 -------------------------------------------------------------------------------
@@ -123,27 +125,35 @@ end
 -------------------------------------------------------------------------------
 if mods["bobplates"] then
   -- liquid fuel --------------------------------------------------------------
-  move_item("liquid-fuel", "petrochem-carbon-fluids", "dac", "fluid")
-  data.raw["fluid"]["liquid-fuel"].icon = nil
-  data.raw["fluid"]["liquid-fuel"].icons =
-    angelsmods.functions.create_liquid_fluid_icon(nil, { { 237, 212, 104 }, { 247, 216, 081 }, { 247, 216, 081 } })
-  OV.barrel_overrides("liquid-fuel", "acid")
+  if data.raw.fluid["liquid-fuel"] then
+    move_item("liquid-fuel", "petrochem-carbon-fluids", "dac", "fluid")
+    data.raw["fluid"]["liquid-fuel"].icon = nil
+    data.raw["fluid"]["liquid-fuel"].icons =
+      angelsmods.functions.create_liquid_fluid_icon(nil, { { 237, 212, 104 }, { 247, 216, 081 }, { 247, 216, 081 } })
+    OV.barrel_overrides("liquid-fuel", "acid")
+  end
 
-  data.raw["recipe"]["liquid-fuel"].always_show_products = true
-  data.raw["recipe"]["liquid-fuel"].icon = nil
-  data.raw["recipe"]["liquid-fuel"].icons = angelsmods.functions.create_liquid_recipe_icon(
-    { "liquid-fuel" },
-    { { 237, 212, 104 }, { 247, 216, 081 }, { 247, 216, 081 } }
-  )
+  if data.raw.recipe["liquid-fuel"] then
+    data.raw["recipe"]["liquid-fuel"].always_show_products = true
+    data.raw["recipe"]["liquid-fuel"].icon = nil
+    data.raw["recipe"]["liquid-fuel"].icons = angelsmods.functions.create_liquid_recipe_icon(
+      { "liquid-fuel" },
+      { { 237, 212, 104 }, { 247, 216, 081 }, { 247, 216, 081 } }
+    )
+  end
   --update bobs tungstic acid to use new icon
-  data.raw.fluid["tungstic-acid"].icons = angelsmods.functions.create_viscous_liquid_fluid_icon(
-    nil,
-    { { 235, 235, 240 }, { 235, 235, 240 }, { 135, 090, 023, 0.75 }, { 135, 090, 023, 0.75 } }
-  )
-  data.raw.fluid["tungstic-acid"].icon = nil
-  data.raw.fluid["tungstic-acid"].icon_size = nil
-  data.raw.fluid["tungstic-acid"].icon_mipmaps = nil
-  data.raw.recipe["tungstic-acid"].icon = nil
+  if data.raw.fluid["tungstic-acid"] then
+    data.raw.fluid["tungstic-acid"].icons = angelsmods.functions.create_viscous_liquid_fluid_icon(
+      nil,
+      { { 235, 235, 240 }, { 235, 235, 240 }, { 135, 090, 023, 0.75 }, { 135, 090, 023, 0.75 } }
+    )
+    data.raw.fluid["tungstic-acid"].icon = nil
+    data.raw.fluid["tungstic-acid"].icon_size = nil
+    data.raw.fluid["tungstic-acid"].icon_mipmaps = nil
+  end
+  if data.raw.recipe["tungstic-acid"] then
+    data.raw.recipe["tungstic-acid"].icon = nil
+  end
   OV.patch_recipes({
     {
       name = "liquid-fuel",

--- a/angelspetrochem/prototypes/override/bobrevamp.lua
+++ b/angelspetrochem/prototypes/override/bobrevamp.lua
@@ -5,28 +5,36 @@ if mods["bobrevamp"] and mods["bobplates"] then
   -----------------------------------------------------------------------------
   -- SOLID FUEL ---------------------------------------------------------------
   -----------------------------------------------------------------------------
-  data.raw.recipe["solid-fuel-from-hydrogen"].icon = nil
-  data.raw.recipe["solid-fuel-from-hydrogen"].icons = angelsmods.functions.create_solid_recipe_icon({
-    { "__angelspetrochem__/graphics/icons/molecules/hydrogen.png", 72 },
-  }, "solid-fuel")
+  local solid_fuel_from_hydrogen = data.raw.recipe["solid-fuel-from-hydrogen"]
+    or data.raw.recipe["bob-solid-fuel-from-hydrogen"]
+  if solid_fuel_from_hydrogen then
+    solid_fuel_from_hydrogen.icon = nil
+    solid_fuel_from_hydrogen.icons = angelsmods.functions.create_solid_recipe_icon({
+      { "__angelspetrochem__/graphics/icons/molecules/hydrogen.png", 72 },
+    }, "solid-fuel")
+  end
 
   -----------------------------------------------------------------------------
   -- RTG ----------------------------------------------------------------------
   -----------------------------------------------------------------------------
   if mods["bobplates"] and settings.startup["bobmods-revamp-rtg"].value then
-    data.raw["item"]["sodium-cobaltate"].icon = "__angelspetrochem__/graphics/icons/solid-sodium-cobaltate.png"
-    data.raw["item"]["sodium-cobaltate"].icon_size = 32
-    move_item("sodium-cobaltate", "petrochem-sodium", "b[sodium]-d[solid-sodium-cobaltate]")
+    local sodium_cobaltate_name = data.raw.item["sodium-cobaltate"] and "sodium-cobaltate"
+      or data.raw.item["bob-sodium-cobaltate"] and "bob-sodium-cobaltate"
+    if sodium_cobaltate_name then
+      data.raw.item[sodium_cobaltate_name].icon = "__angelspetrochem__/graphics/icons/solid-sodium-cobaltate.png"
+      data.raw.item[sodium_cobaltate_name].icon_size = 32
+      move_item(sodium_cobaltate_name, "petrochem-sodium", "b[sodium]-d[solid-sodium-cobaltate]")
 
-    OV.patch_recipes({
-      {
-        name = "sodium-cobaltate",
-        icon = "__angelspetrochem__/graphics/icons/solid-sodium-cobaltate.png",
-        icon_size = 32,
-        subgroup = "petrochem-sodium",
-        order = "b[sodium]-d[solid-sodium-cobaltate]",
-      },
-    })
+      OV.patch_recipes({
+        {
+          name = sodium_cobaltate_name,
+          icon = "__angelspetrochem__/graphics/icons/solid-sodium-cobaltate.png",
+          icon_size = 32,
+          subgroup = "petrochem-sodium",
+          order = "b[sodium]-d[solid-sodium-cobaltate]",
+        },
+      })
+    end
     if settings.startup["bobmods-revamp-hardmode"].value then
       OV.patch_recipes({
         {
@@ -40,6 +48,10 @@ if mods["bobrevamp"] and mods["bobplates"] then
         },
       })
     end
-    OV.add_prereq("rtg", "angels-coal-processing-3")
+    if data.raw.technology["rtg"] then
+      OV.add_prereq("rtg", "angels-coal-processing-3")
+    elseif data.raw.technology["bob-rtg"] then
+      OV.add_prereq("bob-rtg", "angels-coal-processing-3")
+    end
   end
 end

--- a/angelspetrochem/prototypes/override/bobwarfare.lua
+++ b/angelspetrochem/prototypes/override/bobwarfare.lua
@@ -21,16 +21,22 @@ if mods["bobwarfare"] then
   -----------------------------------------------------------------------------
   -- NITROGLYCERIN ------------------------------------------------------------
   -----------------------------------------------------------------------------
-  data.raw["fluid"]["nitroglycerin"].icon = nil
-  data.raw["fluid"]["nitroglycerin"].icons =
-    angelsmods.functions.create_liquid_fluid_icon({ "__bobwarfare__/graphics/icons/nitroglycerin.png", 64 }, "CNO")
+  local nitroglycerin_name = data.raw.fluid["nitroglycerin"] and "nitroglycerin"
+    or data.raw.fluid["bob-nitroglycerin"] and "bob-nitroglycerin"
+  if nitroglycerin_name then
+    data.raw.fluid[nitroglycerin_name].icon = nil
+    data.raw.fluid[nitroglycerin_name].icons =
+      angelsmods.functions.create_liquid_fluid_icon({ "__bobwarfare__/graphics/icons/nitroglycerin.png", 64 }, "CNO")
 
-  data.raw["recipe"]["nitroglycerin"].icon = nil
-  data.raw["recipe"]["nitroglycerin"].icons =
-    angelsmods.functions.create_liquid_recipe_icon({ { "__bobwarfare__/graphics/icons/nitroglycerin.png", 64 } }, "CNO")
-  -- move_item needs to be called before barrel_overrides
-  angelsmods.functions.move_item("nitroglycerin", "petrochem-nitrogen-fluids", "ob", "fluid")
-  OV.barrel_overrides("nitroglycerin", "vanilla")
+    if data.raw.recipe[nitroglycerin_name] then
+      data.raw.recipe[nitroglycerin_name].icon = nil
+      data.raw.recipe[nitroglycerin_name].icons =
+        angelsmods.functions.create_liquid_recipe_icon({ { "__bobwarfare__/graphics/icons/nitroglycerin.png", 64 } }, "CNO")
+    end
+    -- move_item needs to be called before barrel_overrides
+    angelsmods.functions.move_item(nitroglycerin_name, "petrochem-nitrogen-fluids", "ob", "fluid")
+    OV.barrel_overrides(nitroglycerin_name, "vanilla")
+  end
 
   -----------------------------------------------------------------------------
   -- RUBBER -------------------------------------------------------------------

--- a/angelsrefining/data-final-fixes.lua
+++ b/angelsrefining/data-final-fixes.lua
@@ -9,3 +9,10 @@ angelsmods.functions.modify_barreling_recipes()
 angelsmods.functions.create_barreling_fluid_subgroup()
 
 require("prototypes.tips-and-tricks.tips-and-tricks")
+
+-- SeaBlock owns the broad Factorio 2.0 prototype normalizer.  Angel's Refining
+-- still creates/edits barreling recipes in final fixes, so rerun the shared
+-- pass when SeaBlock is loaded to catch any late legacy fields.
+if seablock and seablock.factorio_2_0_compat then
+  seablock.factorio_2_0_compat()
+end

--- a/angelsrefining/info.json
+++ b/angelsrefining/info.json
@@ -1,7 +1,7 @@
 {
   "name": "angelsrefining",
   "version": "0.12.7",
-  "factorio_version": "1.1",
+  "factorio_version": "2.0",
   "title": "Angel's Refining",
   "author": "Arch666Angel",
   "contact": "https://discord.gg/ff5p6KE",

--- a/angelsrefining/prototypes/angels-functions.lua
+++ b/angelsrefining/prototypes/angels-functions.lua
@@ -1000,21 +1000,29 @@ function angelsmods.functions.create_solid_recipe_icon(bot_molecules_icon, solid
   return recipe_icons
 end
 
+-- Factorio 2.0 base/Bob fluids are not completely consistent about color
+-- tables while this mixed 1.1/2.0 pack is loading: some use keyed RGBA fields
+-- and some older Angel helpers pass positional arrays.  Accept both so tint
+-- generation does not crash while still preserving the original color values.
+local function color_component(color, key, index)
+  return color and (color[key] or color[index]) or nil
+end
+
 function angelsmods.functions.get_fluid_recipe_tint(fluid_name)
   -- returns a crafting_machine_tint depending on the fluid color
   local fluid = data.raw.fluid[fluid_name]
   return fluid
       and {
         primary = {
-          r = fluid.base_color.r or 0,
-          g = fluid.base_color.g or 0,
-          b = fluid.base_color.b or 0,
+          r = color_component(fluid.base_color, "r", 1) or 0,
+          g = color_component(fluid.base_color, "g", 2) or 0,
+          b = color_component(fluid.base_color, "b", 3) or 0,
           a = 185 / 255,
         },
         secondary = {
-          r = fluid.flow_color.r or 0,
-          g = fluid.flow_color.g or 0,
-          b = fluid.flow_color.b or 0,
+          r = color_component(fluid.flow_color, "r", 1) or 0,
+          g = color_component(fluid.flow_color, "g", 2) or 0,
+          b = color_component(fluid.flow_color, "b", 3) or 0,
           a = 185 / 255,
         },
       }
@@ -1044,12 +1052,16 @@ function angelsmods.functions.get_recipe_tints(layers, opacity)
       }) do
         if data.raw[type][name] then
           local base = data.raw[type][name]
+          local base_color = base.base_color or {}
+          local r = color_component(base_color, "r", 1) or 0
+          local g = color_component(base_color, "g", 2) or 0
+          local b = color_component(base_color, "b", 3) or 0
           tints[index] = {
-            r = base.base_color.r or 0,
-            g = base.base_color.g or 0,
-            b = base.base_color.b or 0,
-            a = base.base_color.a --if alpha, maintain
-              or ((base.base_color.r < 1 and base.base_color.g < 1) and alpha or alpha * 255),
+            r = r,
+            g = g,
+            b = b,
+            a = color_component(base_color, "a", 4) --if alpha, maintain
+              or ((r < 1 and g < 1) and alpha or alpha * 255),
           }
           break
         end
@@ -1427,7 +1439,13 @@ function angelsmods.functions.add_flag(entity, flag) -- Adds a flag to an item/f
   for _, type in pairs({ "item", "tool", "item-with-entity-data", "fluid" }) do --list of things to hide
     local to_add = data.raw[type][entity] or nil
     if to_add then
-      if type == "fluid" and flag == "hidden" then --also remove barrel if a fluid
+      if flag == "hidden" and (type == "item" or type == "tool" or type == "item-with-entity-data") then
+        -- 2.0 validates item flags more strictly: `hidden` is now a boolean
+        -- field on item-like prototypes, not a value in the flags array.
+        to_add.hidden = true
+      elseif type == "fluid" and flag == "hidden" then --also remove barrel if a fluid
+        -- Fluids also use the boolean field, and Angel's old hide helper is
+        -- responsible for removing the associated barreling/void recipes.
         to_add.hidden = true
         angelsmods.functions.disable_barreling_recipes(entity)
         for _, void_category in pairs({ "water", "chemical" }) do

--- a/angelsrefining/prototypes/generation/angels-fissure.lua
+++ b/angelsrefining/prototypes/generation/angels-fissure.lua
@@ -1,9 +1,5 @@
 data:extend({
   {
-    type = "noise-layer",
-    name = "angels-fissure",
-  },
-  {
     type = "autoplace-control",
     name = "angels-fissure",
     localised_name = { "", "[entity=angels-fissure] ", { "entity-name.angels-fissure" } },

--- a/angelsrefining/prototypes/generation/map-gen-presets.lua
+++ b/angelsrefining/prototypes/generation/map-gen-presets.lua
@@ -1,5 +1,3 @@
-local noise = require("noise")
-
 if mods["angelsexploration"] then
   -- angels exploration takes care of this
 else
@@ -10,9 +8,11 @@ else
 
   local old_probability = data.raw["noise-expression"]["enemy_base_probability"].expression
 
-  local slider = (noise.log2(noise.var("control-setting:angels-biter-slider:size:multiplier")) / (noise.log2(6, 2)))
-
-  data.raw["noise-expression"]["enemy_base_probability"].expression = noise.clamp(slider, 0, 1) * old_probability
+  -- The old code built this as a noise-expression table using the removed
+  -- `noise` helper module.  Factorio 2.0 accepts expression strings here; keep
+  -- Angel's biter slider behavior by multiplying the existing base expression.
+  data.raw["noise-expression"]["enemy_base_probability"].expression =
+    "clamp(log2(var('control-setting:angels-biter-slider:size:multiplier')) / log2(6), 0, 1) * (" .. old_probability .. ")"
 
   data:extend({
     {
@@ -22,11 +22,6 @@ else
       order = "d-a",
       category = "enemy",
       localised_description = { "autoplace-control-description.angels-biter-slider" },
-    },
-    {
-      type = "noise-expression",
-      name = "control-setting:angels-biter-slider:size:multiplier",
-      expression = noise.to_noise_expression(0),
     },
   })
 end

--- a/angelsrefining/prototypes/generation/resource-builder.lua
+++ b/angelsrefining/prototypes/generation/resource-builder.lua
@@ -1,6 +1,10 @@
-local noise = require("noise")
-local tne = noise.to_noise_expression
 local resource_autoplace = require("resource-autoplace")
+
+-- Factorio 2.0 removed the old `particle` prototype type used by Angel's
+-- 1.1 resource generator.  Ore particles are now `optimized-particle`
+-- prototypes, so keep a local reference to that table and generate/look up the
+-- new type everywhere this builder handles resource mining particles.
+local particles = data.raw["optimized-particle"] or {}
 
 --Create autoplace
 local function make_resautoplace(input)
@@ -18,7 +22,7 @@ end
 
 --Create particles
 local function make_particle(input)
-  if not data.raw.particle[input.name .. "-particle"] then
+  if not particles[input.name .. "-particle"] then
     data:extend({
       {
         type = "optimized-particle",
@@ -947,7 +951,7 @@ function angelsmods.functions.make_resource()
       generate_presets(input.name)
       --Create Particle if resource yields items
       if input.type == "item" then
-        if input.get and data.raw.particle[input.get .. "-particle"] then
+        if input.get and particles[input.get .. "-particle"] then
           input.particle = input.get .. "-particle"
         else
           make_particle(input)

--- a/angelsrefining/prototypes/override/refining-override-bobgems.lua
+++ b/angelsrefining/prototypes/override/refining-override-bobgems.lua
@@ -78,12 +78,31 @@ end
 --GEM PROCESSING ------------------------------------------------------------
 -------------------------------------------------------------------------------
 if mods["bobplates"] then
-  data.raw.recipe["bob-ruby-3"].result_count = 1
-  data.raw.recipe["bob-sapphire-3"].result_count = 1
-  data.raw.recipe["bob-emerald-3"].result_count = 1
-  data.raw.recipe["bob-amethyst-3"].result_count = 1
-  data.raw.recipe["bob-topaz-3"].result_count = 1
-  data.raw.recipe["bob-diamond-3"].result_count = 1
+  -- Bob's 2.0 recipes are already in the new `results` shape.  Angel's old
+  -- override used `result_count`; normalize both possible shapes here so the
+  -- gem amount adjustment remains independent of the Bob branch being loaded.
+  local function set_result_amount(recipe_name, amount)
+    local recipe = data.raw.recipe[recipe_name]
+    if not recipe then
+      return
+    end
+    if recipe.results and recipe.results[1] then
+      recipe.results[1].amount = amount
+      return
+    end
+    if recipe.result then
+      recipe.results = { { type = "item", name = recipe.result, amount = amount } }
+      recipe.result = nil
+      recipe.result_count = nil
+    end
+  end
+
+  set_result_amount("bob-ruby-3", 1)
+  set_result_amount("bob-sapphire-3", 1)
+  set_result_amount("bob-emerald-3", 1)
+  set_result_amount("bob-amethyst-3", 1)
+  set_result_amount("bob-topaz-3", 1)
+  set_result_amount("bob-diamond-3", 1)
 end
 
 -------------------------------------------------------------------------------

--- a/angelsrefining/prototypes/override/refining-override-bobwarfare.lua
+++ b/angelsrefining/prototypes/override/refining-override-bobwarfare.lua
@@ -59,20 +59,22 @@ end
 -------------------------------------------------------------------------------
 if mods["bobwarfare"] then
   if mods["bobplates"] then
-    OV.patch_recipes({
-      {
-        name = "heavy-armor-2",
-        ingredients = {
-          { name = "gunmetal-alloy", amount = "cobalt-steel-alloy" },
+    if data.raw.armor["heavy-armor-2"] then
+      OV.patch_recipes({
+        {
+          name = "heavy-armor-2",
+          ingredients = {
+            { name = "gunmetal-alloy", amount = "cobalt-steel-alloy" },
+          },
         },
-      },
-    })
-    data.raw.armor["heavy-armor-2"].localised_name = { "item-name.AB-heavy-armour-2" }
-    OV.remove_prereq("bob-armor-making-3", "cobalt-processing")
-    if mods["angelssmelting"] then
-      OV.add_prereq("bob-armor-making-3", "angels-gunmetal-smelting-1")
-    else
-      OV.add_prereq("bob-armor-making-3", "zinc-processing")
+      })
+      data.raw.armor["heavy-armor-2"].localised_name = { "item-name.AB-heavy-armour-2" }
+      OV.remove_prereq("bob-armor-making-3", "cobalt-processing")
+      if mods["angelssmelting"] then
+        OV.add_prereq("bob-armor-making-3", "angels-gunmetal-smelting-1")
+      else
+        OV.add_prereq("bob-armor-making-3", "zinc-processing")
+      end
     end
   else
     OV.add_prereq("bob-armor-making-3", "logistic-science-pack")

--- a/angelsrefining/prototypes/override/refining-override-water-treatment.lua
+++ b/angelsrefining/prototypes/override/refining-override-water-treatment.lua
@@ -249,16 +249,17 @@ end
 -- LITHIA WATER ---------------------------------------------------------------
 -------------------------------------------------------------------------------
 if mods["bobplates"] then
-  data.raw.fluid["lithia-water"].icons = angelsmods.functions.create_viscous_liquid_fluid_icon(
+  local lithia_water = data.raw.fluid["lithia-water"] and "lithia-water" or "bob-lithia-water"
+  data.raw.fluid[lithia_water].icons = angelsmods.functions.create_viscous_liquid_fluid_icon(
     nil,
     { { 032, 118, 206 }, { 248, 083, 099 }, { 038, 137, 237, 0.8 }, { 255, 073, 072, 0.8 } }
   )
-  data.raw.fluid["lithia-water"].icon = nil
-  data.raw.fluid["lithia-water"].icon_size = nil
-  data.raw.fluid["lithia-water"].icon_mipmaps = nil
-  data.raw.fluid["lithia-water"].base_color = angelsmods.functions.fluid_color("Ws4Tw")
-  data.raw.fluid["lithia-water"].flow_color = angelsmods.functions.flow_color("Ws4Tw")
-  angelsmods.functions.move_item("lithia-water", "water-treatment-fluid", "ea", "fluid")
+  data.raw.fluid[lithia_water].icon = nil
+  data.raw.fluid[lithia_water].icon_size = nil
+  data.raw.fluid[lithia_water].icon_mipmaps = nil
+  data.raw.fluid[lithia_water].base_color = angelsmods.functions.fluid_color("Ws4Tw")
+  data.raw.fluid[lithia_water].flow_color = angelsmods.functions.flow_color("Ws4Tw")
+  angelsmods.functions.move_item(lithia_water, "water-treatment-fluid", "ea", "fluid")
 
   data:extend({
     {
@@ -272,13 +273,13 @@ if mods["bobplates"] then
         { type = "fluid", name = "thermal-water", amount = 100 },
       },
       results = {
-        { type = "fluid", name = "lithia-water", amount = 40 },
+        { type = "fluid", name = lithia_water, amount = 40 },
         { type = "fluid", name = "water-purified", amount = 60 },
       },
       --icon = "__angelsrefining__/graphics/icons/water-thermal-lithia.png",
       --icon_size = 32,
       icons = angelsmods.functions.create_liquid_recipe_icon({
-        "lithia-water",
+        lithia_water,
         "water-purified",
       }, {
         { 243, 135, 000 },
@@ -287,7 +288,7 @@ if mods["bobplates"] then
       }),
       crafting_machine_tint = angelsmods.functions.get_recipe_tints({
         "thermal-water",
-        "lithia-water",
+        lithia_water,
         "water-purified",
       }),
       order = "g[water-thermal-lithia]",

--- a/angelsrefining/prototypes/refining-override.lua
+++ b/angelsrefining/prototypes/refining-override.lua
@@ -48,7 +48,7 @@ if mods["bobplates"] then
     OV.disable_recipe("brine")
   end
   --OVERRIDE BARRELING
-  if data.raw["item-subgroup"]["bob-gas-bottle"] then
+  if data.raw["item-subgroup"]["bob-gas-bottle"] and data.raw.item["empty-canister"] and data.raw.item["gas-canister"] then
     data.raw.item["empty-canister"].subgroup = "angels-fluid-control"
     data.raw.item["empty-canister"].order = "i"
     data.raw.item["gas-canister"].subgroup = "angels-fluid-control"

--- a/angelsrefining/src/mod-config.lua
+++ b/angelsrefining/src/mod-config.lua
@@ -1,5 +1,10 @@
 local sea_pump = require("src.sea-pump")
 
+-- Keep Angel's existing migration code readable while using the Factorio 2.0
+-- persistent-state table.  This function only upgrades the sea-pump storage
+-- schema, so a local compatibility alias is enough.
+local global = storage
+
 return function(configuration_data)
   local mod_changes = configuration_data.mod_changes["angelspump"]
   if mod_changes and mod_changes.new_version ~= (mod_changes.old_version or "") then

--- a/angelsrefining/src/sea-pump.lua
+++ b/angelsrefining/src/sea-pump.lua
@@ -1,5 +1,10 @@
 require("util")
 
+-- Factorio 2.0 removed the old `global` table.  The sea-pump control code has
+-- a small, stable state shape (`SP_data`), so alias it to `storage` instead of
+-- rewriting every getter/setter and risking a migration bug.
+local global = storage
+
 -- Create class ---------------------------------------------------------------
 local sea_pump = {}
 

--- a/angelsrefining/src/starting_items.lua
+++ b/angelsrefining/src/starting_items.lua
@@ -22,15 +22,19 @@ end
 
 function starting_items:configure_starting_items()
   -- configuration settings
-  local technology_overhaul = game.active_mods["angelsindustries"] and settings.startup["angels-enable-tech"].value
+  -- Factorio 2.0 exposes active mods to control scripts as `script.active_mods`
+  -- instead of `game.active_mods`.  Cache it locally so the following Angel's
+  -- Industries/Bob Classes feature gates keep their original shape.
+  local active_mods = script.active_mods
+  local technology_overhaul = active_mods["angelsindustries"] and settings.startup["angels-enable-tech"].value
     or false
   local components_overhaul = technology_overhaul
-    or (game.active_mods["angelsindustries"] and settings.startup["angels-enable-components"].value)
+    or (active_mods["angelsindustries"] and settings.startup["angels-enable-components"].value)
     or false
 
   self:increment_freeplay_starting_item("burner-ore-crusher", 1)
 
-  if game.active_mods["bobclasses"] then -- fix character classes starting point
+  if active_mods["bobclasses"] then -- fix character classes starting point
     if components_overhaul then
       self:increment_freeplay_starting_item("iron-plate", 2)
     end

--- a/angelssmelting/info.json
+++ b/angelssmelting/info.json
@@ -1,7 +1,7 @@
 {
   "name": "angelssmelting",
   "version": "0.6.23",
-  "factorio_version": "1.1",
+  "factorio_version": "2.0",
   "title": "Angel's Smelting",
   "author": "Arch666Angel",
   "contact": "https://discord.gg/ff5p6KE",

--- a/angelssmelting/prototypes/override/smelting-override-alloy-support.lua
+++ b/angelssmelting/prototypes/override/smelting-override-alloy-support.lua
@@ -4,6 +4,17 @@ local OV = angelsmods.functions.OV
 -- ALLOY HANDLING -------------------------------------------------------------
 -------------------------------------------------------------------------------
 if mods["bobplates"] then
+  local function bob_name(type_name, name)
+    if data.raw[type_name] and data.raw[type_name][name] then
+      return name
+    end
+    local prefixed_name = "bob-" .. name
+    if data.raw[type_name] and data.raw[type_name][prefixed_name] then
+      return prefixed_name
+    end
+    return name
+  end
+
   for k, v in pairs(data.raw.recipe) do
     if v.category == "mixing-furnace" then --alien-blue-alloy, alien-orange-alloy
       data.raw.recipe[v.name].category = "blast-smelting"
@@ -36,7 +47,10 @@ if mods["bobplates"] then
   OV.global_replace_item("electric-chemical-furnace", "electric-furnace")
   angelsmods.functions.add_flag("electric-chemical-furnace", "hidden")
   angelsmods.functions.set_next_upgrade("assembling-machine", "electric-chemical-furnace", nil)
-  data.raw["assembling-machine"]["electric-chemical-furnace"].crafting_categories = { "chemical-furnace" }
+  local electric_chemical_furnace = bob_name("assembling-machine", "electric-chemical-furnace")
+  if data.raw["assembling-machine"][electric_chemical_furnace] then
+    data.raw["assembling-machine"][electric_chemical_furnace].crafting_categories = { "chemical-furnace" }
+  end
   OV.disable_recipe("electric-chemical-furnace")
   OV.disable_technology("electric-chemical-furnace")
   OV.remove_prereq("multi-purpose-furnace-1", "electric-chemical-furnace")
@@ -68,16 +82,23 @@ if mods["bobplates"] then
           and { name = "fluid-mixing-furnace", locale = "angels-fluid-ingredient-furnace" }
         or nil,
     }) do
-      --if data.raw["assembling-machine"][rep.name] then
-      data.raw["assembling-machine"][rep.name].localised_name = { "entity-name." .. rep.locale }
-      --end
+      local machine_name = bob_name("assembling-machine", rep.name)
+      if data.raw["assembling-machine"][machine_name] then
+        data.raw["assembling-machine"][machine_name].localised_name = { "entity-name." .. rep.locale }
+      end
     end
     -- tech tree updates
     OV.add_prereq("electric-mixing-furnace", "steel-mixing-furnace")
     OV.remove_prereq("steel-mixing-furnace", "alloy-processing")
     OV.remove_prereq("electric-mixing-furnace", "alloy-processing")
-    data.raw.technology["multi-purpose-furnace-1"].localised_name = { "technology-name.angels-multi-purpose-furnace-1" }
-    data.raw.technology["multi-purpose-furnace-2"].localised_name = { "technology-name.angels-multi-purpose-furnace-2" }
+    local multi_purpose_furnace_1 = bob_name("technology", "multi-purpose-furnace-1")
+    local multi_purpose_furnace_2 = bob_name("technology", "multi-purpose-furnace-2")
+    if data.raw.technology[multi_purpose_furnace_1] then
+      data.raw.technology[multi_purpose_furnace_1].localised_name = { "technology-name.angels-multi-purpose-furnace-1" }
+    end
+    if data.raw.technology[multi_purpose_furnace_2] then
+      data.raw.technology[multi_purpose_furnace_2].localised_name = { "technology-name.angels-multi-purpose-furnace-2" }
+    end
   else --remove metal mixing furnaces if multi-purpose are also removed
     -- remove stone mixing furnace
     OV.global_replace_item("stone-mixing-furnace", "stone-furnace")


### PR DESCRIPTION
Hi! This is a friendly Codex-assisted compatibility patch from a local SeaBlock 2.0 startup workbench.

Please feel completely free to use any individual pieces that are helpful, reshape them, or close this if it overlaps with the current 2.0/dev branch work. I noticed there is already substantial official Angel's 2.0 work, so this is offered mainly as a bundle of compatibility observations and small fixes found while testing SeaBlock startup.

## What changed

- Adds small Factorio 2.0 load fixes across the Angel core mods used by SeaBlock startup testing.
- Updates a few local `factorio_version` declarations to `2.0` for the tested core/addon set.
- Handles `global` -> `storage` in Angel's Refining sea-pump runtime state.
- Handles `game.active_mods` -> `script.active_mods` in startup-item logic.
- Adjusts old hidden-flag, pollution absorption, recipe result, particle, and map-gen/noise-expression shapes toward Factorio 2.0-compatible forms.
- Adds guards for Bob 2.0 helper/name changes encountered while loading SeaBlock with Bob's dev-branch mods.
- Adds comments around the less obvious compatibility changes so pieces can be cherry-picked more easily.

## Why

These changes were found while validating a SeaBlock dependency set on Factorio 2.0 with Quality and Elevated Rails enabled and Space Age disabled. The intent is startup/load compatibility only; this is not a gameplay balance pass.

## Validation

Validated locally as part of a SeaBlock startup harness with Factorio headless 2.0.76:

- `quality` enabled
- `elevated-rails` enabled
- `space-age` disabled
- SeaBlock plus Angel/Bob dependency closure

The harness successfully created a new startup map/save with these Angel-side compatibility fixes plus corresponding SeaBlock-side compatibility shims.

## Attribution

This PR is the result of an OpenAI Codex-assisted porting pass. No personal user information is included here; the intent is simply to offer the patch in case it is useful.
