### PR TITLE
[codex] Fix Petrochem centrifuge pipe positions

### DIFF
--- a/angelspetrochem/prototypes/buildings/centrifuge.lua
+++ b/angelspetrochem/prototypes/buildings/centrifuge.lua
@@ -169,7 +169,11 @@ for _, centrifuge_name in pairs({
   end
 end
 
--- add pipe input to the centrifuge
+-- Add unfiltered fluid input/output boxes to centrifuges so Petrochem can use
+-- them for fluid-based nuclear processing recipes. Centrifuges are 3x3
+-- entities, so their north/south pipe connections need to sit on the tile grid
+-- at y = -1 and y = 1. Fractional offsets can still load, but in Factorio 2.0
+-- they make the pipe pictures render off-center from the visible connection.
 for _, centrifuge_name in pairs({
   "centrifuge",
   "bob-centrifuge-2",
@@ -192,27 +196,25 @@ for _, centrifuge_name in pairs({
       centrifuge.fluid_boxes = {}
     end
 
-    if has_fluid_input_box then
-    else
+    if not has_fluid_input_box then
       table.insert(centrifuge.fluid_boxes, {
         production_type = "input",
         pipe_covers = pipecoverspictures(),
         volume = 1000,
         pipe_connections = {
-          { flow_direction = "input", position = { 0, -1.19 }, direction = defines.direction.north },
-        }, -- assume 3x3 entity collision box
+          { flow_direction = "input", position = { 0, -1 }, direction = defines.direction.north },
+        },
       })
     end
 
-    if has_fluid_output_box then
-    else
+    if not has_fluid_output_box then
       table.insert(centrifuge.fluid_boxes, {
         production_type = "output",
         pipe_covers = pipecoverspictures(),
         volume = 1000,
         pipe_connections = {
-          { flow_direction = "output", position = { 0, 1.19 }, direction = defines.direction.south },
-        }, -- assume 3x3 entity collision box
+          { flow_direction = "output", position = { 0, 1 }, direction = defines.direction.south },
+        },
       })
     end
   end
@@ -237,8 +239,7 @@ for centrifuge_name, centrifuge_categegories in pairs({
           centrifuge_category_present = true
         end
       end
-      if centrifuge_category_present then
-      else
+      if not centrifuge_category_present then
         table.insert(centrifuge.crafting_categories, centrifuge_category)
       end
     end


### PR DESCRIPTION
This is a small Codex-produced patch offered for consideration. Use it if it helps.

## What changed
- Moves the Petrochem-added centrifuge input/output pipe connections from fractional offsets to tile-grid positions.
- Keeps the same north/south input/output layout for the base centrifuge and Bob centrifuges.
- Cleans up nearby empty `if` branches while preserving behavior.

## Why
Angel's Petrochem adds fluid boxes to centrifuges for fluid-based nuclear processing recipes. In Factorio 2.0, the old fractional offsets load but make the pipe pictures render off-center from the visible connection on these 3x3 entities.

Fixes #1293.

## Validation
- `luacheck --config /home/xyf/seablock-agent/.luacheckrc --globals pipecoverspictures -- angelspetrochem/prototypes/buildings/centrifuge.lua`
- `/home/xyf/seablock-agent/.venv/bin/lizard -l lua -C 15 -L 120 angelspetrochem/prototypes/buildings/centrifuge.lua`
- Factorio 2.0.76 headless `--dump-data`; verified `centrifuge`, `bob-centrifuge-2`, and `bob-centrifuge-3` now use `{0, -1}` / `{0, 1}` pipe positions.
- Factorio 2.0.76 headless startup/create passed with local Angel + Bob + SeaBlock mod stack.
