### PR TITLE
[codex] Update petro wagon capacities for Factorio 2.0

### DIFF
--- a/angelsaddons-mobility/prototypes/entities/petro-gas-wagon.lua
+++ b/angelsaddons-mobility/prototypes/entities/petro-gas-wagon.lua
@@ -1,5 +1,11 @@
 local fluid_minimap_representation = data.raw["fluid-wagon"]["fluid-wagon"].minimap_representation
 local fluid_selected_minimap_representation = data.raw["fluid-wagon"]["fluid-wagon"].selected_minimap_representation
+local base_fluid_wagon_capacity = data.raw["fluid-wagon"]["fluid-wagon"].capacity
+-- Factorio 2.0 doubled the base fluid wagon from 25k to 50k. Keep the
+-- non-Petrochem petro wagon aligned with base capacity, and keep the Petrochem
+-- version at its historical 1.6x advantage so it scales to 80k.
+local petro_gas_wagon_capacity = mods["angelspetrochem"] and base_fluid_wagon_capacity * 1.6
+  or base_fluid_wagon_capacity
 
 local funcs = require("prototypes.train-functions")
 local simulations = require("prototypes.factoriopedia-simulations")
@@ -36,7 +42,7 @@ funcs.generate_train_entities({
   minable = { mining_time = 1, result = "angels-petro-gas-wagon" },
   mined_sound = { filename = "__core__/sound/deconstruct-medium.ogg" },
   max_health = 600,
-  capacity = mods["angelspetrochem"] and 40000 or 25000,
+  capacity = petro_gas_wagon_capacity,
   corpse = "medium-remnants",
   dying_explosion = "medium-explosion",
   factoriopedia_simulation = simulations.factoriopedia_petro_tank1,

--- a/angelsaddons-mobility/prototypes/entities/petro-oil-wagon.lua
+++ b/angelsaddons-mobility/prototypes/entities/petro-oil-wagon.lua
@@ -1,5 +1,11 @@
 local fluid_minimap_representation = data.raw["fluid-wagon"]["fluid-wagon"].minimap_representation
 local fluid_selected_minimap_representation = data.raw["fluid-wagon"]["fluid-wagon"].selected_minimap_representation
+local base_fluid_wagon_capacity = data.raw["fluid-wagon"]["fluid-wagon"].capacity
+-- Factorio 2.0 doubled the base fluid wagon from 25k to 50k. Keep the
+-- non-Petrochem petro wagon aligned with base capacity, and keep the Petrochem
+-- version at its historical 1.6x advantage so it scales to 80k.
+local petro_oil_wagon_capacity = mods["angelspetrochem"] and base_fluid_wagon_capacity * 1.6
+  or base_fluid_wagon_capacity
 
 local funcs = require("prototypes.train-functions")
 local simulations = require("prototypes.factoriopedia-simulations")
@@ -33,7 +39,7 @@ funcs.generate_train_entities({
   icon = "__angelsaddons-mobility-graphics-petro__/graphics/icons/petro-oil-wagon.png",
   icon_size = 64,
   flags = { "placeable-neutral", "player-creation", "placeable-off-grid" },
-  capacity = mods["angelspetrochem"] and 40000 or 25000,
+  capacity = petro_oil_wagon_capacity,
   minable = { mining_time = 1, result = "angels-petro-oil-wagon" },
   mined_sound = { filename = "__core__/sound/deconstruct-medium.ogg" },
   max_health = 600,


### PR DESCRIPTION
This is a small Codex-produced patch offered for consideration. Use it if it helps.

## What changed
- Bases Angel's petro gas/oil wagon capacity on the current base fluid wagon capacity.
- Keeps non-Petrochem petro wagons aligned with base fluid wagons.
- Keeps Petrochem-enabled petro wagons at their historical 1.6x advantage, which is 80k now that Factorio 2.0 base wagons are 50k.
- Adds comments explaining the Factorio 2.0 capacity scaling.

## Why
Factorio 2.0 doubled base fluid wagon capacity from 25k to 50k. The petro wagons still used 25k/40k values, leaving the Petrochem wagons below base capacity.

Fixes #1287.

## Validation
- `luacheck --config /home/xyf/seablock-agent/.luacheckrc --globals sound_variations volume_multiplier crash_trigger -- angelsaddons-mobility/prototypes/entities/petro-gas-wagon.lua angelsaddons-mobility/prototypes/entities/petro-oil-wagon.lua`
- `/home/xyf/seablock-agent/.venv/bin/lizard -l lua -C 15 -L 120 angelsaddons-mobility/prototypes/entities/petro-gas-wagon.lua angelsaddons-mobility/prototypes/entities/petro-oil-wagon.lua`
- Factorio 2.0.76 headless `--dump-data` with Angel's Mobility + Petrochem enabled. Verified base fluid wagon = 50000, gas wagon = 80000, oil wagon = 80000.
- Factorio 2.0.76 headless startup/create passed with the local Angel + Bob + SeaBlock mod stack.
