### PR TITLE
[codex] Remove pistol requirements from Exploration weapon recipes

### DIFF
--- a/angelsexploration/prototypes/exploration-override.lua
+++ b/angelsexploration/prototypes/exploration-override.lua
@@ -7,7 +7,10 @@ table.insert(
 if angelsmods.industries then
   local OV = angelsmods.functions.OV
 
-  -- turrets require guns as ingredients, compensate recipe for it as well
+  -- Turrets require guns as ingredients, so compensate the weapon recipes for
+  -- that extra demand. Factorio 2.0 removed the craftable pistol recipe, so the
+  -- early weapon chain must start from ordinary materials instead of consuming
+  -- starter pistols that players cannot replace.
 
   -- gun turret
   OV.patch_recipes({
@@ -15,7 +18,6 @@ if angelsmods.industries then
       name = "submachine-gun",
       ingredients = {
         { "!!" },
-        { type = "item", name = "pistol", amount = 1 },
         { type = "item", name = "iron-plate", amount = 5 },
         { type = "item", name = "iron-gear-wheel", amount = 10 },
       },
@@ -74,7 +76,6 @@ if angelsmods.industries then
       name = "shotgun",
       ingredients = {
         { "!!" },
-        { type = "item", name = "pistol", amount = 2 },
         { type = "item", name = "iron-gear-wheel", amount = 5 },
         { type = "item", name = "iron-plate", amount = 5 },
         { type = "item", name = "wood", amount = 5 },


### PR DESCRIPTION
This is a small Codex-produced patch offered for consideration. Use it if it helps.

## What changed
- Removes `pistol` from the Angel Exploration/Industries overrides for `submachine-gun` and `shotgun`.
- Adds a comment explaining why the early weapon chain cannot consume pistols in Factorio 2.0.

## Why
Factorio 2.0 no longer provides a craftable pistol recipe. Angel Exploration's Industries-mode weapon chain used pistols as ingredients, which can make `submachine-gun` and `shotgun` uncraftable once the starter pistol is consumed or unavailable.

Fixes #1104.

## Validation
- `luacheck --config /home/xyf/seablock-agent/.luacheckrc --globals angelsmods -- angelsexploration/prototypes/exploration-override.lua`
- `/home/xyf/seablock-agent/.venv/bin/lizard -l lua -C 15 -L 120 angelsexploration/prototypes/exploration-override.lua`
- Factorio 2.0.76 headless `--dump-data` with Angel Exploration and its declared Angel dependencies enabled. Verified `submachine-gun` and `shotgun` ingredients no longer include `pistol`.
- Factorio 2.0.76 headless startup/create passed with the local Angel + Bob + SeaBlock mod stack.
